### PR TITLE
Stored special metrics as class properties and updated scorecard poin…

### DIFF
--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -235,6 +235,9 @@ class Scorecard(Base, BaseEstimator):
         self.estimator_ = None
         self.intercept_ = 0
 
+        self._metric_special = None
+        self._metric_missing = None
+
         # auxiliary
         self._target_dtype = None
 
@@ -330,7 +333,7 @@ class Scorecard(Base, BaseEstimator):
         self._check_is_fitted()
 
         df_t = df[self.binning_process_.variable_names]
-        df_t = self.binning_process_.transform(df_t)
+        df_t = self.binning_process_.transform(df_t, metric_special = self._metric_special, metric_missing = self._metric_missing)
         return self.estimator_.predict(df_t)
 
     def predict_proba(self, df):
@@ -350,7 +353,7 @@ class Scorecard(Base, BaseEstimator):
         self._check_is_fitted()
 
         df_t = df[self.binning_process_.variable_names]
-        df_t = self.binning_process_.transform(df_t)
+        df_t = self.binning_process_.transform(df_t, metric_special = self._metric_special, metric_missing = self._metric_missing)
         return self.estimator_.predict_proba(df_t)
 
     def score(self, df):
@@ -450,6 +453,11 @@ class Scorecard(Base, BaseEstimator):
     def _fit(self, df, metric_special, metric_missing, show_digits,
              check_input):
 
+    
+        # Store the metrics for missing and special bins for predictions
+        self._metric_special = metric_special
+        self._metric_missing = metric_missing
+
         time_init = time.perf_counter()
 
         if self.verbose:
@@ -539,6 +547,11 @@ class Scorecard(Base, BaseEstimator):
             binning_table["Variable"] = variable
             binning_table["Coefficient"] = c
             binning_table["Points"] = binning_table[bt_metric] * c
+            if metric_special != 'empirical':
+                binning_table.at[len(binning_table.index)-2, "Points"] = metric_special*c
+            elif metric_missing!= 'empirical':
+                binning_table.at[len(binning_table.index)-1, "Points"] = metric_missing*c
+
             binning_table.index.names = ['Bin id']
             binning_table.reset_index(level=0, inplace=True)
             binning_tables.append(binning_table)

--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -333,7 +333,9 @@ class Scorecard(Base, BaseEstimator):
         self._check_is_fitted()
 
         df_t = df[self.binning_process_.variable_names]
-        df_t = self.binning_process_.transform(df_t, metric_special = self._metric_special, metric_missing = self._metric_missing)
+        df_t = self.binning_process_.transform(df_t,
+                    metric_special=self._metric_special,
+                    metric_missing=self._metric_missing)
         return self.estimator_.predict(df_t)
 
     def predict_proba(self, df):
@@ -353,7 +355,9 @@ class Scorecard(Base, BaseEstimator):
         self._check_is_fitted()
 
         df_t = df[self.binning_process_.variable_names]
-        df_t = self.binning_process_.transform(df_t, metric_special = self._metric_special, metric_missing = self._metric_missing)
+        df_t = self.binning_process_.transform(df_t,
+                    metric_special=self._metric_special,
+                    metric_missing=self._metric_missing)
         return self.estimator_.predict_proba(df_t)
 
     def score(self, df):
@@ -453,7 +457,6 @@ class Scorecard(Base, BaseEstimator):
     def _fit(self, df, metric_special, metric_missing, show_digits,
              check_input):
 
-    
         # Store the metrics for missing and special bins for predictions
         self._metric_special = metric_special
         self._metric_missing = metric_missing
@@ -548,9 +551,11 @@ class Scorecard(Base, BaseEstimator):
             binning_table["Coefficient"] = c
             binning_table["Points"] = binning_table[bt_metric] * c
             if metric_special != 'empirical':
-                binning_table.at[len(binning_table.index)-2, "Points"] = metric_special*c
+                binning_table.at[len(binning_table)-2,
+                                 "Points"] = metric_special * c
             elif metric_missing!= 'empirical':
-                binning_table.at[len(binning_table.index)-1, "Points"] = metric_missing*c
+                binning_table.at[len(binning_table)-1,
+                                 "Points"] = metric_missing * c
 
             binning_table.index.names = ['Bin id']
             binning_table.reset_index(level=0, inplace=True)

--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -3,6 +3,7 @@ Scorecard development.
 """
 
 # Guillermo Navas-Palencia <g.navas.palencia@gmail.com>
+# Kasper De Blieck <kasperdeblieck@hotmail.com>
 # Copyright (C) 2020
 
 import numbers


### PR DESCRIPTION
## Solving issues related to metrics for special bins

* `metric_special` and `metric_missing` are stored in class attributes after fitting. The values are reused in the transformation when predicting a model, so the same metrics are used in both fitting and prediction steps, instead of always using 0 as metric in the predictions. 
* The scorecard points for the missing and special bins are calculated based on the metric specified instead of always using the empirical observations.

Committer: Kasper De Blieck <kasperdeblieck@hotmail.com>