### PR TITLE
fix metric_missing=0 is ignored in Scorecard._fit #226

### DIFF
--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -605,7 +605,7 @@ class Scorecard(Base, BaseEstimator):
 
                 binning_table.loc[
                     nt-1-n_specials:nt-2, "Points"] = metric_special * c
-            elif metric_missing != 'empirical':
+            if metric_missing != 'empirical':
                 binning_table.loc[nt-1, "Points"] = metric_missing * c
 
             binning_table.index.names = ['Bin id']

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -450,3 +450,26 @@ def test_verbose():
     with open("tests/results/test_scorecard_verbose.txt", "w") as f:
         with redirect_stdout(f):
             scorecard.fit(X, y)
+
+
+def test_missing_metrics():
+    data = pd.DataFrame(
+        {'target': np.hstack(
+            (np.tile(np.array([0, 1]), 50),
+             np.array([0]*90 + [1]*10)
+             )
+         ),
+         'var': [np.nan] * 100 + ['A'] * 100}
+    )
+
+    binning_process = BinningProcess(['var'])
+    scaling_method_params = {'min': 0, 'max': 100}
+
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(),
+        scaling_method="min_max",
+        scaling_method_params=scaling_method_params
+    ).fit(data, data.target)
+
+    assert scorecard.table()['Points'].iloc[-1] == approx(0, rel=1e-6)


### PR DESCRIPTION
Very simple fix for a very troublesome bug.