### PR TITLE
Use np.empty/zeros dtype arg instead of astype'ing

### DIFF
--- a/optbinning/binning/binning.py
+++ b/optbinning/binning/binning.py
@@ -902,7 +902,7 @@ class OptimalBinning(BaseOptimalBinning):
         if len(n_nonevent) <= 1:
             self._status = "OPTIMAL"
             self._splits_optimal = splits
-            self._solution = np.zeros(len(splits)).astype(bool)
+            self._solution = np.zeros(len(splits), dtype=bool)
 
             if self.verbose:
                 logger.warning("Optimizer: {} bins after pre-binning."
@@ -1083,8 +1083,8 @@ class OptimalBinning(BaseOptimalBinning):
             indices = np.digitize(x, splits_prebinning, right=False)
             n_bins = n_splits + 1
 
-        n_nonevent = np.empty(n_bins).astype(np.int64)
-        n_event = np.empty(n_bins).astype(np.int64)
+        n_nonevent = np.empty(n_bins, dtype=np.int64)
+        n_event = np.empty(n_bins, dtype=np.int64)
 
         for i in range(n_bins):
             mask = (indices == i)

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -905,11 +905,11 @@ class ContinuousOptimalBinning(OptimalBinning):
             indices = np.digitize(x, splits_prebinning, right=False)
             n_bins = n_splits + 1
 
-        n_records = np.empty(n_bins).astype(np.int64)
+        n_records = np.empty(n_bins, dtype=np.int64)
         sums = np.empty(n_bins)
         ssums = np.empty(n_bins)
         stds = np.zeros(n_bins)
-        n_zeros = np.empty(n_bins).astype(np.int64)
+        n_zeros = np.empty(n_bins, dtype=np.int64)
         min_t = np.full(n_bins, -np.inf)
         max_t = np.full(n_bins, np.inf)
 

--- a/optbinning/binning/cp.py
+++ b/optbinning/binning/cp.py
@@ -273,7 +273,7 @@ class BinningCP:
             solution = np.array([self.solver_.BooleanValue(self._x[i, i])
                                  for i in range(self._n)]).astype(bool)
         else:
-            solution = np.zeros(self._n).astype(bool)
+            solution = np.zeros(self._n, dtype=bool)
             solution[-1] = True
 
         return status_name, solution

--- a/optbinning/binning/distributed/bsketch.py
+++ b/optbinning/binning/distributed/bsketch.py
@@ -159,8 +159,8 @@ class BSketch:
         bins : tuple of arrays of size n_splits + 1.
         """
         n_bins = len(splits) + 1
-        bins_e = np.zeros(n_bins).astype(np.int64)
-        bins_ne = np.zeros(n_bins).astype(np.int64)
+        bins_e = np.zeros(n_bins, dtype=np.int64)
+        bins_ne = np.zeros(n_bins, dtype=np.int64)
 
         indices_e, count_e = _indices_count(
             self.sketch, self._sketch_e, splits)

--- a/optbinning/binning/ls.py
+++ b/optbinning/binning/ls.py
@@ -223,7 +223,7 @@ class BinningLS:
             solution = np.array([self._x[i].value
                                  for i in range(self._n)]).astype(bool)
         else:
-            solution = np.zeros(self._n).astype(bool)
+            solution = np.zeros(self._n, dtype=bool)
             solution[-1] = True
 
         return status_name, solution

--- a/optbinning/binning/mip.py
+++ b/optbinning/binning/mip.py
@@ -199,7 +199,7 @@ class BinningMIP:
             else:
                 status_name = "UNKNOWN"
 
-            solution = np.zeros(self._n).astype(bool)
+            solution = np.zeros(self._n, dtype=bool)
             solution[-1] = True
 
         return status_name, solution

--- a/optbinning/binning/multiclass_binning.py
+++ b/optbinning/binning/multiclass_binning.py
@@ -602,7 +602,7 @@ class MulticlassOptimalBinning(OptimalBinning):
         time_postprocessing = time.perf_counter()
 
         if not len(splits):
-            n_event = np.empty(self._n_classes).astype(np.int64)
+            n_event = np.empty(self._n_classes, dtype=np.int64)
 
             for i, cl in enumerate(self._classes):
                 n_event[i] = target_info(y_clean, cl)[0]
@@ -671,7 +671,7 @@ class MulticlassOptimalBinning(OptimalBinning):
         if not len(n_nonevent):
             self._status = "OPTIMAL"
             self._splits_optimal = splits
-            self._solution = np.zeros(len(splits)).astype(bool)
+            self._solution = np.zeros(len(splits), dtype=bool)
 
             if self.verbose:
                 logger.warning("Optimizer: no bins after pre-binning.")
@@ -790,9 +790,9 @@ class MulticlassOptimalBinning(OptimalBinning):
         indices = np.digitize(x, splits_prebinning, right=False)
 
         n_bins = n_splits + 1
-        n_nonevent = np.empty((n_bins, self._n_classes)).astype(np.int64)
-        n_event = np.empty((n_bins, self._n_classes)).astype(np.int64)
-        mask_remove = np.zeros(n_bins).astype(bool)
+        n_nonevent = np.empty((n_bins, self._n_classes), dtype=np.int64)
+        n_event = np.empty((n_bins, self._n_classes), dtype=np.int64)
+        mask_remove = np.zeros(n_bins, dtype=bool)
 
         for idx, cl in enumerate(self._classes):
             y1 = (y == cl)

--- a/optbinning/binning/multidimensional/mip_2d.py
+++ b/optbinning/binning/multidimensional/mip_2d.py
@@ -109,7 +109,7 @@ class Binning2DMIP:
             else:
                 status_name = "UNKNOWN"
 
-            solution = np.zeros(self._n_rectangles).astype(bool)
+            solution = np.zeros(self._n_rectangles, dtype=bool)
 
         return status_name, solution
 

--- a/optbinning/binning/uncertainty/binning_scenarios.py
+++ b/optbinning/binning/uncertainty/binning_scenarios.py
@@ -678,9 +678,9 @@ class SBOptimalBinning(OptimalBinning):
             return splits_prebinning, np.array([]), np.array([])
 
         n_bins = n_splits + 1
-        n_nonevent = np.empty((n_bins, self._n_scenarios)).astype(np.int64)
-        n_event = np.empty((n_bins, self._n_scenarios)).astype(np.int64)
-        mask_remove = np.zeros(n_bins).astype(bool)
+        n_nonevent = np.empty((n_bins, self._n_scenarios), dtype=np.int64)
+        n_event = np.empty((n_bins, self._n_scenarios), dtype=np.int64)
+        mask_remove = np.zeros(n_bins, dtype=bool)
 
         for s in range(self._n_scenarios):
             y0 = (y[s] == 0)
@@ -733,7 +733,7 @@ class SBOptimalBinning(OptimalBinning):
         if not len(n_nonevent):
             self._status = "OPTIMAL"
             self._splits_optimal = splits
-            self._solution = np.zeros(len(splits)).astype(bool)
+            self._solution = np.zeros(len(splits), dtype=bool)
 
             if self.verbose:
                 logger.warning("Optimizer: no bins after pre-binning.")

--- a/optbinning/scorecard/monitoring.py
+++ b/optbinning/scorecard/monitoring.py
@@ -78,7 +78,7 @@ def print_psi_report(df_psi):
     n_bins = len(splits) + 1
     indices = np.digitize(psi, splits, right=True)
 
-    psi_bins = np.empty(n_bins).astype(np.int64)
+    psi_bins = np.empty(n_bins, dtype=np.int64)
     for i in range(n_bins):
         mask = (indices == i)
         psi_bins[i] = len(psi[mask])
@@ -109,7 +109,7 @@ def print_tests_report(df_tests):
     n_bins = len(splits) + 1
     indices = np.digitize(pvalues, splits, right=True)
 
-    pvalue_bins = np.empty(n_bins).astype(np.int64)
+    pvalue_bins = np.empty(n_bins, dtype=np.int64)
     for i in range(n_bins):
         mask = (indices == i)
         pvalue_bins[i] = len(pvalues[mask])
@@ -501,10 +501,10 @@ class ScorecardMonitoring(BaseEstimator):
         indices_e = np.digitize(score_expected, splits, right=True)
 
         if self._target_dtype == "binary":
-            n_nonevent_a = np.empty(n_bins).astype(np.int64)
-            n_event_a = np.empty(n_bins).astype(np.int64)
-            n_nonevent_e = np.empty(n_bins).astype(np.int64)
-            n_event_e = np.empty(n_bins).astype(np.int64)
+            n_nonevent_a = np.empty(n_bins, dtype=np.int64)
+            n_event_a = np.empty(n_bins, dtype=np.int64)
+            n_nonevent_e = np.empty(n_bins, dtype=np.int64)
+            n_event_e = np.empty(n_bins, dtype=np.int64)
 
             y0_a = (y_actual == 0)
             y1_a = ~ y0_a
@@ -524,8 +524,8 @@ class ScorecardMonitoring(BaseEstimator):
             n_records_a = n_nonevent_a + n_event_a
             n_records_e = n_nonevent_e + n_event_e
         else:
-            n_records_a = np.empty(n_bins).astype(np.int64)
-            n_records_e = np.empty(n_bins).astype(np.int64)
+            n_records_a = np.empty(n_bins, dtype=np.int64)
+            n_records_e = np.empty(n_bins, dtype=np.int64)
             mean_a = np.empty(n_bins)
             mean_e = np.empty(n_bins)
             std_a = np.empty(n_bins)
@@ -784,8 +784,8 @@ class ScorecardMonitoring(BaseEstimator):
 
             n_bins = te.max() + 1
 
-            n_records_a = np.empty(n_bins).astype(np.int64)
-            n_records_e = np.empty(n_bins).astype(np.int64)
+            n_records_a = np.empty(n_bins, dtype=np.int64)
+            n_records_e = np.empty(n_bins, dtype=np.int64)
 
             for i in range(n_bins):
                 n_records_a[i] = np.count_nonzero(ta == i)


### PR DESCRIPTION
Hypothetical fix to #270.

I tried to replicate the issue there, but couldn't: the empty arrays were filled with zeros.  So I'm not sure my guess there was correct.  But while I was doing this, I ran timeit on the `.astype` vs `dtype` arg approaches, and the latter was significantly faster.