### PR TITLE
Expose monotonic trend analysis to summary table.

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -419,15 +419,18 @@ class BaseBinningProcess:
                     "iv": optb.binning_table.iv,
                     "gini": optb.binning_table.gini,
                     "js": optb.binning_table.js,
-                    "quality_score": optb.binning_table.quality_score}
+                    "quality_score": optb.binning_table.quality_score,
+                    "monotonic_trend": optb.binning_table.monotonic_trend}
             elif self._target_dtype == "multiclass":
                 metrics = {
                     "js": optb.binning_table.js,
-                    "quality_score": optb.binning_table.quality_score}
+                    "quality_score": optb.binning_table.quality_score,
+                    "monotonic_trend": optb.binning_table.monotonic_trend}
             elif self._target_dtype == "continuous":
                 metrics = {
                     "woe": optb.binning_table.woe,
-                    "quality_score": optb.binning_table.quality_score}
+                    "quality_score": optb.binning_table.quality_score,
+                    "monotonic_trend": optb.binning_table.monotonic_trend}
 
             info = {**info, **metrics}
             self._variable_stats[name] = info
@@ -933,7 +936,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         df_summary.rename(columns={"index": "name"}, inplace=True)
         df_summary["selected"] = self._support
 
-        columns = ["name", "dtype", "status", "selected", "n_bins"]
+        columns = ["name", "dtype", "status", "monotonic_trend", "selected", "n_bins"]
         columns += _METRICS[self._target_dtype]["metrics"]
 
         return df_summary[columns]

--- a/optbinning/binning/binning_statistics.py
+++ b/optbinning/binning/binning_statistics.py
@@ -489,6 +489,7 @@ class BinningTable:
         self._gini = None
         self._n_specials = None
         self._quality_score = None
+        self._type_mono = None
         self._ks = None
 
         self._bin_str = False
@@ -962,7 +963,7 @@ class BinningTable:
                                                     self._hhi_norm)
 
         # Monotonic trend
-        type_mono = type_of_monotonic_trend(self._event_rate[:-2])
+        self._type_mono = type_of_monotonic_trend(self._event_rate[:-2])
 
         report = (
             "---------------------------------------------\n"
@@ -987,7 +988,7 @@ class BinningTable:
             "  Significance tests\n\n{}\n"
             ).format(self._gini, self._iv, self._js, self._hellinger,
                      self._triangular, self._ks, self._hhi, self._hhi_norm,
-                     cramer_v, self._quality_score, type_mono, df_tests_string)
+                     cramer_v, self._quality_score, self._type_mono, df_tests_string)
 
         if print_output:
             print(report)
@@ -1089,6 +1090,17 @@ class BinningTable:
 
         return self._quality_score
 
+    @property
+    def monotonic_trend(self):
+        """The monotonic trend.
+
+        Returns
+        -------
+        monotonic_trend : str
+        """
+        _check_is_analyzed(self)
+
+        return self._type_mono
 
 class MulticlassBinningTable:
     """Binning table to summarize optimal binning of a numerical variable with
@@ -1128,6 +1140,7 @@ class MulticlassBinningTable:
         self._hhi_norm = None
         self._n_specials = None
         self._quality_score = None
+        self._type_mono = None
 
         self._bin_str = False
         self._is_built = False
@@ -1447,8 +1460,8 @@ class MulticlassBinningTable:
         monotonic_string = ""
 
         for i in range(len(self.classes)):
-            type_mono = type_of_monotonic_trend(self._event_rate[:-2, i])
-            monotonic_string += mono_string.format(i, type_mono)
+            self._type_mono = type_of_monotonic_trend(self._event_rate[:-2, i])
+            monotonic_string += mono_string.format(i, self._type_mono)
 
         report = (
             "-------------------------------------------------\n"
@@ -1503,6 +1516,17 @@ class MulticlassBinningTable:
 
         return self._quality_score
 
+    @property
+    def monotonic_trend(self):
+        """The monotonic trend.
+
+        Returns
+        -------
+        monotonic_trend : str
+        """
+        _check_is_analyzed(self)
+
+        return self._type_mono
 
 class ContinuousBinningTable:
     """Binning table to summarize optimal binning of a numerical or categorical
@@ -1566,6 +1590,7 @@ class ContinuousBinningTable:
     """
     def __init__(self, name, dtype, special_codes, splits, n_records, sums,
                  stds, min_target, max_target, n_zeros, min_x=None, max_x=None,
+                 monotonic_score_kendalltau=None, monotonic_score_spearmanr=None,
                  categories=None, cat_others=None, user_splits=None):
         
         self.name = name
@@ -1580,6 +1605,8 @@ class ContinuousBinningTable:
         self.n_zeros = n_zeros
         self.min_x = min_x
         self.max_x = max_x
+        self.monotonic_score_kendalltau = monotonic_score_kendalltau
+        self.monotonic_score_spearmanr = monotonic_score_spearmanr
         self.categories = categories
         self.cat_others = cat_others if cat_others is not None else []
         self.user_splits = user_splits
@@ -2008,7 +2035,7 @@ class ContinuousBinningTable:
             rwoe, p_values, self._hhi_norm)
 
         # Monotonic trend
-        type_mono = type_of_monotonic_trend(self._mean[:-2])
+        self._type_mono = type_of_monotonic_trend(self._mean[:-2])
 
         report = (
             "-------------------------------------------------\n"
@@ -2025,10 +2052,13 @@ class ContinuousBinningTable:
             "    Quality score       {:>15.8f}\n"
             "\n"
             "  Monotonic trend       {:>15}\n"
+            "  Monotonic score (kendalltau)       {:>15f}\n"
+            "  Monotonic score (spearmanr)       {:>15f}\n"
             "\n"
             "  Significance tests\n\n{}\n"
             ).format(self._iv, self._woe, rwoe, self._hhi, self._hhi_norm,
-                     self._quality_score, type_mono, df_tests_string)
+                     self._quality_score, self._type_mono,
+                     self.monotonic_score_kendalltau, self.monotonic_score_spearmanr, df_tests_string)
 
         if print_output:
             print(report)
@@ -2084,4 +2114,15 @@ class ContinuousBinningTable:
         _check_is_analyzed(self)
 
         return self._quality_score
-        
+
+    @property
+    def monotonic_trend(self):
+        """The monotonic trend.
+
+        Returns
+        -------
+        monotonic_trend : str
+        """
+        _check_is_analyzed(self)
+
+        return self._type_mono

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -9,6 +9,7 @@ import numbers
 import time
 import json
 
+from scipy.stats import kendalltau, spearmanr
 from sklearn.utils import check_array
 
 import numpy as np
@@ -715,10 +716,17 @@ class ContinuousOptimalBinning(OptimalBinning):
             min_x = None
             max_x = None
 
+        if self.dtype == "numerical":
+            monotonic_score_kendalltau, kendalltau_pvalue = kendalltau(x_clean, y_clean)
+            monotonic_score_spearmanr, spearmanr_pvalue = spearmanr(x_clean, y_clean)
+        else:
+            monotonic_score_kendalltau = None
+            monotonic_score_spearmanr = None
+
         self._binning_table = ContinuousBinningTable(
             self.name, self.dtype, self.special_codes, self._splits_optimal,
             self._n_records, self._sums, self._stds, self._min_target,
-            self._max_target, self._n_zeros, min_x, max_x, self._categories,
+            self._max_target, self._n_zeros, min_x, max_x, monotonic_score_kendalltau, monotonic_score_spearmanr, self._categories,
             self._cat_others, self.user_splits)
 
         self._time_postprocessing = time.perf_counter() - time_postprocessing


### PR DESCRIPTION
Hi, Guillermo.

Thanks a lot for such great package optbinning. 
I used it to variable analysis a lot. 
One thing is very cool, this lib has great monotonic analysis.  
1) This monotonic trend results are useful.  
please check paper: https://ojs.aaai.org/index.php/AAAI/article/view/7055

2) This monotonic analysis can used in boost trees by setting monotonic constraints
see: https://xgboost.readthedocs.io/en/stable/tutorials/monotonic.html
see: http://scikit-learn.org/stable/auto_examples/ensemble/plot_monotonic_constraints.html
see: https://catboost.ai/en/docs/references/training-parameters/common#monotone_constraints

Thus:  I modified your develop code by 2 parts. 

1.  Export the monotonic trend result to binning process summary dataframe.
![monotonic_trend](https://github.com/guillermo-navas-palencia/optbinning/assets/5748162/6f3c27e3-f01d-4abc-8dc8-8de0f624963c)

2. Add ranking correlation analysis for continuous binning process to double check monotonic trend output. 
![monotonic_score](https://github.com/guillermo-navas-palencia/optbinning/assets/5748162/21961645-e890-49d0-bde1-755cc4c6429a)

That's all. 

Thank you again. 

