### PR TITLE
Packaging improvements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+        python-version: ['3.7', '3.8', '3.9', '3.10', "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-12]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,9 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9']
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        ]
     )

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import os
 import sys
 
 from setuptools import find_packages, setup, Command
-from setuptools.command.test import test as TestCommand
-
 
 long_description = '''
 The optimal binning is the optimal discretization of a variable into bins
@@ -32,20 +30,6 @@ class CleanCommand(Command):
 
     def run(self):
         os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
-
-
-# test suites
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = []
-
-    def run_tests(self):
-        # import here, because outside the eggs aren't loaded
-        import pytest
-        errcode = pytest.main(self.test_args)
-        sys.exit(errcode)
 
 
 # install requirements
@@ -89,7 +73,7 @@ setup(
     include_package_data=True,
     license="Apache Licence 2.0",
     url="https://github.com/guillermo-navas-palencia/optbinning",
-    cmdclass={'clean': CleanCommand, 'test': PyTest},
+    cmdclass={'clean': CleanCommand},
     python_requires='>=3.7',
     install_requires=install_requires,
     tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import sys
 
 from setuptools import find_packages, setup, Command
 
@@ -43,15 +42,10 @@ install_requires = [
     'scipy>=1.6.0',
 ]
 
-# test requirements
-tests_require = [
-    'pytest',
-    'coverage'
-]
-
 # extra requirements
 extras_require = {
     'distributed': ['pympler', 'tdigest'],
+    'test': ['coverage', 'flake8', 'pytest', 'pyarrow'],
 }
 
 
@@ -76,7 +70,6 @@ setup(
     cmdclass={'clean': CleanCommand},
     python_requires='>=3.7',
     install_requires=install_requires,
-    tests_require=tests_require,
     extras_require=extras_require,
     classifiers=[
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
General packaging improvements. Happy to adjust as needed, just let me know :).

* Remove testcommand from the setup.py. It is deprecated and the package will no longer install/build in November.
    * See https://github.com/pypa/setuptools/issues/4519
* Expand the test suite to cover python 3.10-3.12

It might be time to consider dropping support/testing for python 3.7 and 3.8. They are both end of life and the CI might not be able to run against them. I'm unsure if some of the C extension dependencies will install on them. Possibly old versions of the packages.


The main reason for the PR:

```
<string>:7: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        By 2024-Nov-15, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
C:\Users\rm13\AppData\Local\Temp\build-env-i_ls03r0\Lib\site-packages\setuptools\_distutils\dist.py:261: UserWarning: Unknown distribution option: 'tests_require'

```
