### PR TITLE
Allow numpy 2.0+ and fix deprecation warnings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
 
-        python-version: ['3.7', '3.8', '3.9', '3.10', "3.11", "3.12"]
+        python-version: ['3.9', '3.10', "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-12]
 
     steps:
@@ -30,10 +30,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
         pip install -r requirements.txt
-        pip install pympler tdigest
     - name: Install package
       run: |
-        pip install -e .[distributed,test]
+        pip install -e .[distributed,test,ecos]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ To include batch and stream binning algorithms (this option is not required for 
 
   pip install optbinning[distributed]
 
+To include support for the `ecos <https://github.com/embotech/ecos>`_ solver:
+
+.. code-block:: text
+
+  pip install optbinning[ecos]
+
 To install from source, download or clone the git repository
 
 .. code-block:: text

--- a/optbinning/binning/multidimensional/binning_statistics_2d.py
+++ b/optbinning/binning/multidimensional/binning_statistics_2d.py
@@ -387,7 +387,7 @@ class BinningTable2D(BinningTable):
 
             er = er + [er[-1]]
             axtop.step(np.arange(self.n + 1) - 0.5, er,
-                       label=path, where="post")
+                       label=str(path), where="post")
 
         for i in range(self.n):
             axtop.axvline(i + 0.5, color="grey", linestyle="--", alpha=0.5)
@@ -417,7 +417,7 @@ class BinningTable2D(BinningTable):
                     self.P == p, axis=0).max()) for p in path], [])
 
             er = er + [er[-1]]
-            axright.step(er, np.arange(self.m + 1) - 0.5, label=path,
+            axright.step(er, np.arange(self.m + 1) - 0.5, label=str(path),
                          where="pre")
 
         for j in range(self.m):
@@ -772,7 +772,7 @@ class ContinuousBinningTable2D(ContinuousBinningTable):
 
             er = er + [er[-1]]
             axtop.step(np.arange(self.n + 1) - 0.5, er,
-                       label=path, where="post")
+                       label=str(path), where="post")
 
         for i in range(self.n):
             axtop.axvline(i + 0.5, color="grey", linestyle="--", alpha=0.5)
@@ -802,7 +802,7 @@ class ContinuousBinningTable2D(ContinuousBinningTable):
                     self.P == p, axis=0).max()) for p in path], [])
 
             er = er + [er[-1]]
-            axright.step(er, np.arange(self.m + 1) - 0.5, label=path,
+            axright.step(er, np.arange(self.m + 1) - 0.5, label=str(path),
                          where="pre")
 
         for j in range(self.m):

--- a/optbinning/binning/preprocessing.py
+++ b/optbinning/binning/preprocessing.py
@@ -31,7 +31,7 @@ def categorical_transform(x, y):
 
 def categorical_cutoff(x, y, cutoff=0.01):
     cutoff_count = np.ceil(cutoff * len(x))
-    cat_count = pd.value_counts(x)
+    cat_count = pd.Series(x).value_counts()
     cat_others = cat_count[cat_count < cutoff_count].index.values
     mask_others = pd.Series(x).isin(cat_others).values
 

--- a/optbinning/scorecard/counterfactual/problem_data.py
+++ b/optbinning/scorecard/counterfactual/problem_data.py
@@ -21,7 +21,13 @@ def problem_data(scorecard, X):
         sc["Points"] = sc["Mean"] * sc["Coefficient"]
 
     # Linear model coefficients
-    intercept = float(scorecard.estimator_.intercept_)
+
+    # Only index into the intercept if it is an array, it is a scalar otherwise 
+    if isinstance(scorecard.estimator_.intercept_, np.ndarray):
+        intercept = float(scorecard.estimator_.intercept_[0])
+    else:
+        intercept = float(scorecard.estimator_.intercept_)
+
     coef = scorecard.estimator_.coef_.ravel()
 
     # Big-M parameters (min, max) points.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class CleanCommand(Command):
 # install requirements
 install_requires = [
     'matplotlib',
-    'numpy>=1.16.1,<2',
+    'numpy>=1.16.1',
     'ortools>=9.4',
     'pandas',
     'ropwr>=1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ install_requires = [
 extras_require = {
     'distributed': ['pympler', 'tdigest'],
     'test': ['coverage', 'flake8', 'pytest', 'pyarrow'],
+    # For ecos support: https://github.com/embotech/ecos 
+    'ecos': ['ecos']
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,14 @@ install_requires = [
 # extra requirements
 extras_require = {
     'distributed': ['pympler', 'tdigest'],
-    'test': ['coverage', 'flake8', 'pytest', 'pyarrow'],
+    'test': [
+        'coverage', 
+        'flake8',
+        'pytest',
+        'pyarrow',
+        'pympler',
+        'tdigest',
+    ],
     # For ecos support: https://github.com/embotech/ecos 
     'ecos': ['ecos']
 }
@@ -82,8 +89,6 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,5 @@ coverage
 flake8
 pytest
 pyarrow
+pympler
+tdigest

--- a/tests/test_binning_piecewise.py
+++ b/tests/test_binning_piecewise.py
@@ -174,7 +174,7 @@ def test_default():
     optb.fit(x, y)
 
     optb.binning_table.build()
-    assert optb.binning_table.iv == approx(5.87152846, rel=1e-6)
+    assert optb.binning_table.iv == approx(5.87474602, rel=1e-6)
 
     with raises(ValueError):
         optb.binning_table.plot(metric="new_metric")
@@ -188,7 +188,7 @@ def test_default_discontinuous():
     optb.fit(x, y)
 
     optb.binning_table.build()
-    assert optb.binning_table.iv == approx(5.84252707, rel=1e-6)
+    assert optb.binning_table.iv == approx(5.84465825, rel=1e-6)
 
 
 def test_bounds_transform():
@@ -197,11 +197,11 @@ def test_bounds_transform():
 
     x_transform_woe = optb.transform(x, metric="woe")
     assert x_transform_woe[:4] == approx(
-        [3.9899792, 4.2806587, 4.17226985, -3.25509338], rel=1e-6)
+        [3.99180564, 4.28245092, 4.17407503, -3.2565373], rel=1e-6)
 
     x_transform_event_rate = optb.transform(x, metric="event_rate")
     assert x_transform_event_rate[:4] == approx(
-        [0.03021225, 0.02276486, 0.02530506, 0.97760445], rel=1e-6)
+        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-6)
 
 
 def test_bounds_fit_transform():
@@ -211,13 +211,11 @@ def test_bounds_fit_transform():
         x, y, lb=0.001, ub=0.999, metric="woe")
 
     assert x_transform_woe[:4] == approx(
-        [3.9899792, 4.2806587, 4.17226985, -3.25509338], rel=1e-6)
-
+        [3.9918056, 4.2824509, 4.17407503, -3.25653732], rel=1e-6)
     x_transform_event_rate = optb.fit_transform(
         x, y, lb=0.001, ub=0.999, metric="event_rate")
-
     assert x_transform_event_rate[:4] == approx(
-        [0.03021225, 0.02276486, 0.02530506, 0.97760445], rel=1e-6)
+        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-6)
 
 
 def test_solvers():
@@ -226,7 +224,7 @@ def test_solvers():
         optb.fit(x, y)
 
         optb.binning_table.build()
-        assert optb.binning_table.iv == approx(5.87152846, rel=1e-6)
+        assert optb.binning_table.iv == approx(5.87474602, rel=1e-6)
 
 
 def test_user_splits():

--- a/tests/test_continuous_binning_piecewise.py
+++ b/tests/test_continuous_binning_piecewise.py
@@ -80,7 +80,7 @@ def test_special_codes():
         name=variable, monotonic_trend="convex", special_codes=special_codes)
     optb.fit(x, y)
 
-    x_transform = optb.transform([np.NaN], metric_missing='empirical')
+    x_transform = optb.transform([np.nan], metric_missing='empirical')
     assert x_transform == approx([17.94], rel=1e-6)
 
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -184,7 +184,7 @@ def test_default():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(-43.65762593147646, rel=1e-6)
     assert sc_max == approx(42.69694657427327, rel=1e-6)
@@ -204,7 +204,7 @@ def test_default_continuous():
 
     sct = scorecard.table(style="detailed")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(-43.261900687199045, rel=1e-6)
     assert sc_max == approx(100.28829019286185, rel=1e-6)
@@ -229,7 +229,7 @@ def test_scaling_method_pdo_odd():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(-612.2266586867094, rel=1e-6)
     assert sc_max == approx(1879.4396115559216, rel=1e-6)
@@ -253,7 +253,7 @@ def test_scaling_method_min_max():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(300, rel=1e-6)
     assert sc_max == approx(850, rel=1e-6)
@@ -277,7 +277,7 @@ def test_intercept_based():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(300 - scorecard.intercept_, rel=1e-6)
     assert sc_max == approx(850 - scorecard.intercept_, rel=1e-6)
@@ -301,7 +301,7 @@ def test_reverse_scorecard():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(300, rel=1e-6)
     assert sc_max == approx(850, rel=1e-6)
@@ -325,7 +325,7 @@ def test_rounding():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(201, rel=1e-6)
     assert sc_max == approx(851, rel=1e-6)
@@ -350,7 +350,7 @@ def test_rounding_pdo_odds():
 
     sct = scorecard.table(style="summary")
     sc_min, sc_max = sct.groupby("Variable").agg(
-        {'Points': [np.min, np.max]}).sum()
+        {'Points': ['min', 'max']}).sum()
 
     assert sc_min == approx(-612, rel=1e-6)
     assert sc_max == approx(1880, rel=1e-6)

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -186,8 +186,8 @@ def test_default():
     sc_min, sc_max = sct.groupby("Variable").agg(
         {'Points': ['min', 'max']}).sum()
 
-    assert sc_min == approx(-43.65762593147646, rel=1e-6)
-    assert sc_max == approx(42.69694657427327, rel=1e-6)
+    assert sc_min == approx(-43.5354465187911, rel=1e-6)
+    assert sc_max == approx(42.55760963498596, rel=1e-6)
 
 
 def test_default_continuous():
@@ -231,8 +231,8 @@ def test_scaling_method_pdo_odd():
     sc_min, sc_max = sct.groupby("Variable").agg(
         {'Points': ['min', 'max']}).sum()
 
-    assert sc_min == approx(-612.2266586867094, rel=1e-6)
-    assert sc_max == approx(1879.4396115559216, rel=1e-6)
+    assert sc_min == approx(-608.2909715472422, rel=1e-6)
+    assert sc_max == approx(1875.829531813342, rel=1e-6)
 
 
 def test_scaling_method_min_max():
@@ -327,7 +327,7 @@ def test_rounding():
     sc_min, sc_max = sct.groupby("Variable").agg(
         {'Points': ['min', 'max']}).sum()
 
-    assert sc_min == approx(201, rel=1e-6)
+    assert sc_min == approx(200, rel=1e-6)
     assert sc_max == approx(851, rel=1e-6)
 
 
@@ -352,8 +352,8 @@ def test_rounding_pdo_odds():
     sc_min, sc_max = sct.groupby("Variable").agg(
         {'Points': ['min', 'max']}).sum()
 
-    assert sc_min == approx(-612, rel=1e-6)
-    assert sc_max == approx(1880, rel=1e-6)
+    assert sc_min == approx(-609, rel=1e-6)
+    assert sc_max == approx(1876, rel=1e-6)
 
 
 def test_estimator_not_coef():
@@ -403,12 +403,23 @@ def test_predict_score():
 
     assert pred[:5] == approx([0, 0, 0, 0, 0])
 
-    assert pred_proba[:5, 1] == approx(
-        [1.15260206e-06, 9.79035720e-06, 7.52481206e-08, 1.12438599e-03,
-         9.83145644e-06], rel=1e-6)
+    expected_pred_proba = [
+        1.18812864e-06, 
+        1.01521192e-05, 
+        7.65959946e-08, 
+        1.09683243e-03,
+        9.99982719e-06
+    ]
+    assert pred_proba[:5, 1] == approx(expected_pred_proba, rel=1e-6)
 
-    assert score[:5] == approx([652.16590046, 638.52659074, 669.56413105,
-                                608.27744027, 638.49988325], rel=1e-6)
+    expected_score = [
+        652.16890659, 
+        638.45026205, 
+        669.70058258, 
+        608.50009151,
+        638.54691686
+    ]
+    assert score[:5] == approx(expected_score, rel=1e-6)
 
 
 def test_information():

--- a/tests/test_scorecard_monitoring.py
+++ b/tests/test_scorecard_monitoring.py
@@ -119,7 +119,7 @@ def test_default_binary():
 
     # Check psi_table
     psi_table = monitoring.psi_table()
-    assert psi_table.PSI.sum() == approx(0.003536079105130241)
+    assert psi_table.PSI.sum() == approx(0.002224950381423254)
 
     # Check psi_variable_table
     with raises(ValueError):
@@ -134,7 +134,7 @@ def test_default_binary():
     # Check tests table
     tests_table = monitoring.tests_table()
     assert tests_table["p-value"].values[:2] == approx(
-        [0.00077184, 0.51953576], rel=1e-4)
+        [0.00250006, 0.49480006], rel=1e-4)
 
     # Check system stability report
     with open("tests/results/test_scorecard_monitoring_default.txt", "w") as f:


### PR DESCRIPTION
May want to merge https://github.com/guillermo-navas-palencia/optbinning/pull/335 first to get more test coverage.

I've divided each fix out into a separate commit to show the specific deprecation warning it is fixing. They are fairly minor things but should keep the package healthy for a good while. They'll start raising errors soon. Figured it was best to get them handled before.

Also, added the `ecsos` extra for users who need it since cvxpy no longer will install it [link](https://www.cvxpy.org/updates/index.html#ecos-deprecation).

Let me know thoughts or if you'd like any changes.