### PR TITLE
Increase ortools lowest version to 9.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 numpy>=1.16.1
-ortools>=9.4,<9.12
+ortools>=9.11,<9.12
 pandas
 ropwr>=1.0.0
 scikit-learn>=1.0.2


### PR DESCRIPTION
This PR increases the lowest allowed version `ortools` to `9.11` to avoid an issue where users on Apple silicon macs experience deadlocks when `pyarrow` is installed in their environment.