### PR TITLE
Fix std in the summary statistics

### DIFF
--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -920,7 +920,7 @@ class ContinuousOptimalBinning(OptimalBinning):
             n_records[i] = np.sum(sw[mask])
             ymask = sw[mask] * y[mask]
             sums[i] = np.sum(ymask)
-            ssums[i] = np.sum(ymask ** 2)
+            ssums[i] = np.sum(sw[mask] * (y[mask] ** 2))
             n_zeros[i] = np.count_nonzero(ymask == 0)
             if len(ymask):
                 stds[i] = np.std(ymask)


### PR DESCRIPTION
Hi Guillermo,

This PR fixes #324.

When `sample_weight` is provided, the `ssum` calculation needs to multiply the weight after $y^2$ instead of `ymask` (multiply weight first and then take the square). It is related with #323 at some level (both are about sample weight) but needs a separate fix.

```math
\begin{align}
std 
&= \frac{\sum w_i (y_i-\bar{y})^2}{\sum w_i} \\
&= \frac{\sum w_i y_i^2 + \bar{y}^2\sum w_i - 2\bar{y}\sum w_i y_i}{\sum w_i}\\
&= \frac{\sum w_i y_i^2 + \bar{y}^2\sum w_i - 2\bar{y}^2\sum w_i}{\sum w_i}\\
&= \frac{\sum w_i y_i^2 - \bar{y}^2\sum w_i}{\sum w_i}\\
&= \frac{\sum w_i y_i^2}{\sum w_i} - \bar{y}^2\\
&= \texttt{np.sqrt(s_ssums / s_n_records - mean ** 2)}
\end{align}
```
where s_ssums = $\sum w_i y_i^2$.

I used the test code in #324 to test the fix. Row 3 (group [8.5, 9.5)) now has std=0 as expected.

**Before**
<img width="551" alt="image" src="https://github.com/user-attachments/assets/1a3a5920-10ab-4b14-819f-6f89d5343015" />

**After**
<img width="575" alt="image" src="https://github.com/user-attachments/assets/bce57c6f-f8fa-46df-a086-1ce81e3a3fce" />


