### PR TITLE
feat(python): add python 3.13 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
 
-        python-version: ['3.9', '3.10', "3.11", "3.12"]
+        python-version: ['3.9', '3.10', "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
-        pip install -r requirements.txt
     - name: Install package
       run: |
         pip install -e .[distributed,test,ecos]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,9 @@ jobs:
 
         python-version: ['3.9', '3.10', "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      # We're running in ci, no need for interaction https://matplotlib.org/stable/users/explain/figure/backends.html#static-backends 
+      MPLBACKEND: Agg
 
     steps:
     - uses: actions/checkout@v2

--- a/optbinning/binning/cp.py
+++ b/optbinning/binning/cp.py
@@ -77,9 +77,11 @@ class BinningCP:
                                 for j in range(i)]) for i in range(n)]) -
                            regularization * (pmax - pmin))
         else:
-            model.Maximize(sum([(V[i][i] * x[i, i]) +
-                           sum([(V[i][j] - V[i][j+1]) * x[i, j]
-                                for j in range(i)]) for i in range(n)]))
+            sum_diagonal = sum([V[i][i] * x[i, i] for i in range(n)])
+            model.Maximize(sum_diagonal +
+                           sum([
+                               sum([(V[i][j] - V[i][j+1]) * x[i, j]
+                                    for j in range(i)]) for i in range(n)]))
 
         # Constraint: unique assignment
         self.add_constraint_unique_assignment(model, n, x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-matplotlib
-numpy>=1.16.1
-ortools>=9.4,<9.12
-pandas
-ropwr>=1.0.0
-scikit-learn>=1.6.0
-scipy>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class CleanCommand(Command):
 install_requires = [
     'matplotlib',
     'numpy>=1.16.1',
-    'ortools>=9.4,<9.12',
+    'ortools>=9.4,<9.15',
     'pandas',
     'ropwr>=1.0.0',
     'scikit-learn>=1.6.0',
@@ -93,5 +93,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class CleanCommand(Command):
 install_requires = [
     'matplotlib',
     'numpy>=1.16.1',
-    'ortools>=9.4,<9.15',
+    'ortools>=9.4,<9.16,!=9.12.4544',
     'pandas',
     'ropwr>=1.0.0',
     'scikit-learn>=1.6.0',

--- a/tests/test_binning_piecewise.py
+++ b/tests/test_binning_piecewise.py
@@ -196,11 +196,11 @@ def test_bounds_transform():
 
     x_transform_woe = optb.transform(x, metric="woe")
     assert x_transform_woe[:4] == approx(
-        [3.99180564, 4.28245092, 4.17407503, -3.2565373], rel=1e-6)
+        [3.99180564, 4.28245092, 4.17407503, -3.2565373], rel=1e-5)
 
     x_transform_event_rate = optb.transform(x, metric="event_rate")
     assert x_transform_event_rate[:4] == approx(
-        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-6)
+        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-5)
 
 
 def test_bounds_fit_transform():
@@ -210,11 +210,11 @@ def test_bounds_fit_transform():
         x, y, lb=0.001, ub=0.999, metric="woe")
 
     assert x_transform_woe[:4] == approx(
-        [3.9918056, 4.2824509, 4.17407503, -3.25653732], rel=1e-6)
+        [3.9918056, 4.2824509, 4.17407503, -3.25653732], rel=1e-5)
     x_transform_event_rate = optb.fit_transform(
         x, y, lb=0.001, ub=0.999, metric="event_rate")
     assert x_transform_event_rate[:4] == approx(
-        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-6)
+        [0.03015878, 0.02272502, 0.02526056, 0.97763604], rel=1e-5)
 
 
 def test_solvers():

--- a/tests/test_continuous_binning_piecewise.py
+++ b/tests/test_continuous_binning_piecewise.py
@@ -49,7 +49,7 @@ def test_fit_transform():
 
 def test_special_codes():
     variable = "INDUS"
-    x = df[variable].values
+    x = df[variable].values.copy()
 
     x[:50] = -9
     x[50:100] = -8

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -470,10 +470,11 @@ def test_missing_metrics():
              np.array([0]*90 + [1]*10)
              )
          ),
-         'var': [np.nan] * 100 + ['A'] * 100}
+         'var': pd.array([np.nan] * 100 + ['A'] * 100, dtype=object)}
     )
 
-    binning_process = BinningProcess(['var'])
+    binning_process = BinningProcess(['var'],
+                                      categorical_variables=['var'])
     scaling_method_params = {'min': 0, 'max': 100}
 
     scorecard = Scorecard(


### PR DESCRIPTION
* Allow ortools <9.15 (9.14 is the current version)
* Requires updates to transitive dependencies i.e. cvxpy and potentially ropwr

Closes https://github.com/guillermo-navas-palencia/optbinning/issues/364 https://github.com/guillermo-navas-palencia/optbinning/issues/347

Also removed the requirements file so it doesn't have to be changed in multiple places. Let me know if this is ok, can add back if it's there for a reason.