### PR TITLE
Replace deprecated force_all_finite parameter and update scikit-learn version requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ OptBinning requires
 * ortools (>=9.4)
 * pandas
 * ropwr (>=1.0.0)
-* scikit-learn (>=1.0.2)
+* scikit-learn (>=1.6.0)
 * scipy (>=1.6.0)
 
 OptBinning[distributed] requires additional packages

--- a/optbinning/binning/binning.py
+++ b/optbinning/binning/binning.py
@@ -793,7 +793,7 @@ class OptimalBinning(BaseOptimalBinning):
                 if self.dtype == "numerical":
                     user_splits = check_array(
                         self.user_splits, ensure_2d=False, dtype=None,
-                        force_all_finite=True)
+                        ensure_all_finite=True)
 
                     if len(set(user_splits)) != len(user_splits):
                         raise ValueError("User splits are not unique.")

--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -1085,10 +1085,10 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         # check X and y data
         if check_input:
             X = check_array(X, ensure_2d=False, dtype=None,
-                            force_all_finite='allow-nan')
+                            ensure_all_finite='allow-nan')
 
             y = check_array(y, ensure_2d=False, dtype=None,
-                            force_all_finite=True)
+                            ensure_all_finite=True)
 
             check_consistent_length(X, y)
 

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -642,7 +642,7 @@ class ContinuousOptimalBinning(OptimalBinning):
                 if self.dtype == "numerical":
                     user_splits = check_array(
                         self.user_splits, ensure_2d=False, dtype=None,
-                        force_all_finite=True)
+                        ensure_all_finite=True)
 
                     if len(set(user_splits)) != len(user_splits):
                         raise ValueError("User splits are not unique.")

--- a/optbinning/binning/mdlp.py
+++ b/optbinning/binning/mdlp.py
@@ -99,8 +99,8 @@ class MDLP(BaseEstimator):
     def _fit(self, x, y):
         _check_parameters(**self.get_params())
 
-        x = check_array(x, ensure_2d=False, force_all_finite=True)
-        y = check_array(y, ensure_2d=False, force_all_finite=True)
+        x = check_array(x, ensure_2d=False, ensure_all_finite=True)
+        y = check_array(y, ensure_2d=False, ensure_all_finite=True)
 
         idx = np.argsort(x)
         x = x[idx]

--- a/optbinning/binning/metrics.py
+++ b/optbinning/binning/metrics.py
@@ -14,8 +14,8 @@ from sklearn.utils import check_consistent_length
 
 
 def _check_x_y(x, y):
-    x = check_array(x, ensure_2d=False, force_all_finite=True)
-    y = check_array(y, ensure_2d=False, force_all_finite=True)
+    x = check_array(x, ensure_2d=False, ensure_all_finite=True)
+    y = check_array(y, ensure_2d=False, ensure_all_finite=True)
 
     check_consistent_length(x, y)
 

--- a/optbinning/binning/multiclass_binning.py
+++ b/optbinning/binning/multiclass_binning.py
@@ -565,7 +565,7 @@ class MulticlassOptimalBinning(OptimalBinning):
                             .format(n_splits))
 
             user_splits = check_array(self.user_splits, ensure_2d=False,
-                                      dtype=None, force_all_finite=True)
+                                      dtype=None, ensure_all_finite=True)
 
             if len(set(user_splits)) != len(user_splits):
                 raise ValueError("User splits are not unique.")

--- a/optbinning/binning/multidimensional/preprocessing_2d.py
+++ b/optbinning/binning/multidimensional/preprocessing_2d.py
@@ -53,13 +53,13 @@ def split_data_2d(dtype_x, dtype_y, x, y, z, special_codes_x=None,
     """
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
         y = check_array(y, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
         z = check_array(z, ensure_2d=False, dtype=None,
-                        force_all_finite=True)
+                        ensure_all_finite=True)
 
         check_consistent_length(x, y, z)
 

--- a/optbinning/binning/multidimensional/transformations_2d.py
+++ b/optbinning/binning/multidimensional/transformations_2d.py
@@ -121,10 +121,10 @@ def transform_binary_target(dtype_x, dtype_y, splits_x, splits_y, x, y,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
         y = check_array(y, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
     y = np.asarray(y)
@@ -198,10 +198,10 @@ def transform_continuous_target(dtype_x, dtype_y, splits_x, splits_y, x, y,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
         y = check_array(y, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
     y = np.asarray(y)

--- a/optbinning/binning/piecewise/transformations.py
+++ b/optbinning/binning/piecewise/transformations.py
@@ -72,7 +72,7 @@ def transform_binary_target(splits, x, c, lb, ub, n_nonevent, n_event,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
 
@@ -144,7 +144,7 @@ def transform_continuous_target(splits, x, c, lb, ub, n_records_special,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
 

--- a/optbinning/binning/preprocessing.py
+++ b/optbinning/binning/preprocessing.py
@@ -166,10 +166,10 @@ def split_data(dtype, x, y, special_codes=None, cat_cutoff=None,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
         y = check_array(y, ensure_2d=False, dtype=None,
-                        force_all_finite=True)
+                        ensure_all_finite=True)
 
         check_consistent_length(x, y)
 

--- a/optbinning/binning/transformations.py
+++ b/optbinning/binning/transformations.py
@@ -243,7 +243,7 @@ def transform_binary_target(splits, dtype, x, n_nonevent, n_event,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
 
@@ -330,7 +330,7 @@ def transform_multiclass_target(splits, x, n_event, special_codes, metric,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
 
@@ -401,7 +401,7 @@ def transform_continuous_target(splits, dtype, x, n_records, sums,
 
     if check_input:
         x = check_array(x, ensure_2d=False, dtype=None,
-                        force_all_finite='allow-nan')
+                        ensure_all_finite='allow-nan')
 
     x = np.asarray(x)
 

--- a/optbinning/binning/uncertainty/binning_scenarios.py
+++ b/optbinning/binning/uncertainty/binning_scenarios.py
@@ -526,7 +526,7 @@ class SBOptimalBinning(OptimalBinning):
         if self.user_splits is not None:
             user_splits = check_array(
                 self.user_splits, ensure_2d=False, dtype=None,
-                force_all_finite=True)
+                ensure_all_finite=True)
 
             if len(set(user_splits)) != len(user_splits):
                 raise ValueError("User splits are not unique.")

--- a/optbinning/scorecard/plots.py
+++ b/optbinning/scorecard/plots.py
@@ -16,8 +16,8 @@ from sklearn.utils import check_consistent_length
 
 
 def _check_arrays(y, y_pred):
-    y = check_array(y, ensure_2d=False, force_all_finite=True)
-    y_pred = check_array(y_pred, ensure_2d=False, force_all_finite=True)
+    y = check_array(y, ensure_2d=False, ensure_all_finite=True)
+    y_pred = check_array(y_pred, ensure_2d=False, ensure_all_finite=True)
 
     check_consistent_length(y, y_pred)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy>=1.16.1
 ortools>=9.4,<9.12
 pandas
 ropwr>=1.0.0
-scikit-learn>=1.0.2
+scikit-learn>=1.6.0
 scipy>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'ortools>=9.4,<9.12',
     'pandas',
     'ropwr>=1.0.0',
-    'scikit-learn>=1.0.2',
+    'scikit-learn>=1.6.0',
     'scipy>=1.6.0',
 ]
 


### PR DESCRIPTION
## Summary
This PR updates all usages of the deprecated `force_all_finite` parameter to use the new `ensure_all_finite` parameter in `sklearn.utils.check_array` function calls and bumps the minimum scikit-learn version requirement to 1.6.0.

## Background
As of scikit-learn 1.6, the `force_all_finite` parameter in `sklearn.utils.check_array` has been deprecated and renamed to `ensure_all_finite`. The deprecated parameter will be removed entirely in scikit-learn 1.8. To ensure forward compatibility and eliminate deprecation warnings, we're updating to use the new parameter name and requiring the minimum version where this change was introduced.

## Changes Made
- Replaced all instances of `force_all_finite` with `ensure_all_finite` in `check_array()` function calls
- Updated scikit-learn version requirement from `scikit-learn>=1.0.2` to `scikit-learn>=1.6.0` in:
 - `requirements.txt` / `setup.py` (as applicable)
- Maintained identical functionality - only the parameter name has changed
