### PR TITLE
Fix binning_table.plot()

### DIFF
--- a/optbinning/binning/binning_statistics.py
+++ b/optbinning/binning/binning_statistics.py
@@ -778,7 +778,7 @@ class BinningTable:
                 handle_missing = mpatches.Patch(hatch="\\", alpha=0.1)
                 label_missing = "Bin missing"
 
-                ax2.plot(pos_missing, metric_values[pos_missing], marker="o",
+                ax2.plot(pos_missing, metric_values[-1], marker="o",
                          color="black")
 
             if add_special and add_missing:


### PR DESCRIPTION
When passing `add_special = False` and `add_missing=True` to
`BinningTable.binning_table.plot()` method, the
WoE value for "Missing" category is incorrectly specified.

The `pos_missing` was pointing incorrectly.

I propose to change the positioning for Missing as -1, as
we always have the Missing category at the end (if we want to add it).

Related to Issue #376 