### PR TITLE
Fix read_json() not restoring state needed by transform() (#387)

### DIFF
--- a/optbinning/binning/binning.py
+++ b/optbinning/binning/binning.py
@@ -1213,9 +1213,11 @@ class OptimalBinning(BaseOptimalBinning):
         opt_bin_dict['min_x'] = table.min_x
         opt_bin_dict['max_x'] = table.max_x
         opt_bin_dict['categories'] = (
-            list(table.categories) if table.categories is not None else None)
+            np.asarray(table.categories).tolist()
+            if table.categories is not None else None)
         opt_bin_dict['cat_others'] = (
-            list(table.cat_others) if table.cat_others is not None else None)
+            np.asarray(table.cat_others).tolist()
+            if table.cat_others is not None else None)
         opt_bin_dict['user_splits'] = (
             list(table.user_splits) if table.user_splits is not None
             else None)

--- a/optbinning/binning/binning.py
+++ b/optbinning/binning/binning.py
@@ -1212,9 +1212,13 @@ class OptimalBinning(BaseOptimalBinning):
 
         opt_bin_dict['min_x'] = table.min_x
         opt_bin_dict['max_x'] = table.max_x
-        opt_bin_dict['categories'] = table.categories
-        opt_bin_dict['cat_others'] = table.cat_others
-        opt_bin_dict['user_splits'] = table.user_splits
+        opt_bin_dict['categories'] = (
+            list(table.categories) if table.categories is not None else None)
+        opt_bin_dict['cat_others'] = (
+            list(table.cat_others) if table.cat_others is not None else None)
+        opt_bin_dict['user_splits'] = (
+            list(table.user_splits) if table.user_splits is not None
+            else None)
 
         return opt_bin_dict
 
@@ -1237,8 +1241,9 @@ class OptimalBinning(BaseOptimalBinning):
 
     def read_json(self, path):
         """
-        Read json file containing split points and set them as the new split
-        points.
+        Load a fitted binning object previously saved with ``to_json``,
+        restoring the state required to call ``transform`` and to inspect
+        ``binning_table``.
 
         Parameters
         ----------
@@ -1254,3 +1259,13 @@ class OptimalBinning(BaseOptimalBinning):
                 bin_table_attr[key] = np.array(bin_table_attr[key])
 
         self._binning_table = BinningTable(**bin_table_attr)
+
+        # Restore the internal state used by ``transform``. Without this,
+        # a binning object reloaded via ``read_json`` raises a TypeError
+        # on ``transform`` because these attributes are only set during
+        # ``fit`` and remain None otherwise.
+        self._splits_optimal = bin_table_attr['splits']
+        self._n_nonevent = bin_table_attr['n_nonevent']
+        self._n_event = bin_table_attr['n_event']
+        self._categories = bin_table_attr['categories']
+        self._cat_others = bin_table_attr['cat_others']

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -1022,17 +1022,22 @@ class ContinuousOptimalBinning(OptimalBinning):
 
         opt_bin_dict['min_x'] = table.min_x
         opt_bin_dict['max_x'] = table.max_x
-        opt_bin_dict['categories'] = table.categories
-        opt_bin_dict['cat_others'] = table.cat_others
-        opt_bin_dict['user_splits'] = table.user_splits
+        opt_bin_dict['categories'] = (
+            list(table.categories) if table.categories is not None else None)
+        opt_bin_dict['cat_others'] = (
+            list(table.cat_others) if table.cat_others is not None else None)
+        opt_bin_dict['user_splits'] = (
+            list(table.user_splits) if table.user_splits is not None
+            else None)
 
         with open(path, "w") as write_file:
             json.dump(opt_bin_dict, write_file)
 
     def read_json(self, path):
         """
-        Read json file containing split points and set them as the new split
-        points.
+        Load a fitted binning object previously saved with ``to_json``,
+        restoring the state required to call ``transform`` and to inspect
+        ``binning_table``.
 
         Parameters
         ----------
@@ -1051,3 +1056,13 @@ class ContinuousOptimalBinning(OptimalBinning):
                 cont_table_attr[key] = np.array(cont_table_attr[key])
 
         self._binning_table = ContinuousBinningTable(**cont_table_attr)
+
+        # Restore the internal state used by ``transform``. Without this,
+        # a binning object reloaded via ``read_json`` raises a TypeError
+        # on ``transform`` because these attributes are only set during
+        # ``fit`` and remain None otherwise.
+        self._splits_optimal = cont_table_attr['splits']
+        self._n_records = cont_table_attr['n_records']
+        self._sums = cont_table_attr['sums']
+        self._categories = cont_table_attr['categories']
+        self._cat_others = cont_table_attr['cat_others']

--- a/optbinning/binning/multiclass_binning.py
+++ b/optbinning/binning/multiclass_binning.py
@@ -907,8 +907,9 @@ class MulticlassOptimalBinning(OptimalBinning):
 
     def read_json(self, path):
         """
-        Read json file containing split points and set them as the new split
-        points.
+        Load a fitted binning object previously saved with ``to_json``,
+        restoring the state required to call ``transform`` and to inspect
+        ``binning_table``.
 
         Parameters
         ----------
@@ -925,5 +926,12 @@ class MulticlassOptimalBinning(OptimalBinning):
         for key in multi_table_attr.keys():
             if isinstance(multi_table_attr[key], list):
                 multi_table_attr[key] = np.array(multi_table_attr[key])
+
+        # Restore the internal state used by ``transform``. Without this,
+        # a binning object reloaded via ``read_json`` raises a TypeError
+        # on ``transform`` because these attributes are only set during
+        # ``fit`` and remain None otherwise.
+        self._splits_optimal = multi_table_attr['splits']
+        self._n_event = multi_table_attr['n_event']
 
         self._binning_table = MulticlassBinningTable(**multi_table_attr)

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -570,3 +570,42 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def test_to_json_read_json(tmp_path):
+    # A binning object reloaded via read_json must reproduce the same
+    # transform as the originally fitted object. See GH issue #387.
+    optb = OptimalBinning(name=variable, dtype="numerical")
+    optb.fit(x, y)
+
+    path = str(tmp_path / "optb.json")
+    optb.to_json(path)
+
+    optb_loaded = OptimalBinning(name=variable, dtype="numerical")
+    optb_loaded.read_json(path)
+
+    assert optb_loaded.transform(x) == approx(optb.transform(x), rel=1e-6)
+    assert (optb_loaded.transform(x, metric="bins") ==
+            optb.transform(x, metric="bins")).all()
+
+
+def test_to_json_read_json_categorical(tmp_path):
+    # categories/cat_others are pandas/numpy array-likes and must be made
+    # JSON-serializable before being written out, otherwise to_json raises
+    # (e.g. "Object of type ndarray/ArrowStringArray is not JSON
+    # serializable"). See GH issue #387.
+    rng = np.random.RandomState(0)
+    x_cat = rng.choice(np.array(['a', 'b', 'c', 'd', 'e']), size=500)
+    y_cat = rng.randint(0, 2, 500)
+
+    optb = OptimalBinning(name="x_cat", dtype="categorical")
+    optb.fit(x_cat, y_cat)
+
+    path = str(tmp_path / "optb_cat.json")
+    optb.to_json(path)
+
+    optb_loaded = OptimalBinning(name="x_cat", dtype="categorical")
+    optb_loaded.read_json(path)
+
+    assert optb_loaded.transform(x_cat) == approx(
+        optb.transform(x_cat), rel=1e-6)

--- a/tests/test_continuous_binning.py
+++ b/tests/test_continuous_binning.py
@@ -277,3 +277,40 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def test_to_json_read_json(tmp_path):
+    # A binning object reloaded via read_json must reproduce the same
+    # transform as the originally fitted object. See GH issue #387.
+    optb = ContinuousOptimalBinning(name=variable, dtype="numerical")
+    optb.fit(x, y)
+
+    path = str(tmp_path / "optb.json")
+    optb.to_json(path)
+
+    optb_loaded = ContinuousOptimalBinning(name=variable, dtype="numerical")
+    optb_loaded.read_json(path)
+
+    assert optb_loaded.transform(x) == approx(optb.transform(x), rel=1e-6)
+
+
+def test_to_json_read_json_categorical(tmp_path):
+    # categories/cat_others are pandas/numpy array-likes and must be made
+    # JSON-serializable before being written out, otherwise to_json raises
+    # (e.g. "Object of type ndarray/ArrowStringArray is not JSON
+    # serializable"). See GH issue #387.
+    rng = np.random.RandomState(0)
+    x_cat = rng.choice(np.array(['a', 'b', 'c', 'd', 'e']), size=500)
+    y_cat = rng.randn(500)
+
+    optb = ContinuousOptimalBinning(name="x_cat", dtype="categorical")
+    optb.fit(x_cat, y_cat)
+
+    path = str(tmp_path / "optb_cat.json")
+    optb.to_json(path)
+
+    optb_loaded = ContinuousOptimalBinning(name="x_cat", dtype="categorical")
+    optb_loaded.read_json(path)
+
+    assert optb_loaded.transform(x_cat) == approx(
+        optb.transform(x_cat), rel=1e-6)

--- a/tests/test_multiclass_binning.py
+++ b/tests/test_multiclass_binning.py
@@ -226,3 +226,19 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def test_to_json_read_json(tmp_path):
+    # A binning object reloaded via read_json must reproduce the same
+    # transform as the originally fitted object. See GH issue #387.
+    optb = MulticlassOptimalBinning(name=variable)
+    optb.fit(x, y)
+
+    path = str(tmp_path / "optb.json")
+    optb.to_json(path)
+
+    optb_loaded = MulticlassOptimalBinning(name=variable)
+    optb_loaded.read_json(path)
+
+    assert (optb_loaded.transform(x, metric="mean_woe") ==
+            approx(optb.transform(x, metric="mean_woe"), rel=1e-5))


### PR DESCRIPTION
Closes #387.

to_json()/read_json() only round-tripped the display data
(_binning_table), not the internal attributes transform() actually
reads (_splits_optimal and friends). A reloaded object therefore raised
TypeError: object of type 'NoneType' has no len() on the first
transform() call. Fixed in OptimalBinning, ContinuousOptimalBinning,
and MulticlassOptimalBinning by restoring those attributes from the
parsed JSON right after read_json() rebuilds the binning table.

While testing this I also found to_json() crashes on categorical-dtype
binnings (categories/cat_others/user_splits are array-likes and
aren't JSON-serializable - this path had no test coverage before this PR
on any dtype). Fixed the same way splits/n_event/etc. already are:
converted to plain lists before json.dump.

Added regression tests for the numerical case (all 3 classes) and the
categorical case (OptimalBinning, ContinuousOptimalBinning -
MulticlassOptimalBinning has no categorical support). Confirmed each
new test fails with the original bug's exact error when the fix is
reverted, and passes with it applied. No regressions in the rest of the
suite.

Didn't touch release_notes.rst since entries there seem to be added in
bulk at release time rather than per-PR - happy to add a line if you'd
rather I did.