### PR TITLE
Fix binning_transform_params leaking between variables

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -1429,15 +1429,18 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
             if self.binning_transform_params is not None:
                 params = self.binning_transform_params.get(name, {})
 
-            metric = params.get("metric", metric)
-            metric_missing = params.get("metric_missing", metric_missing)
-            metric_special = params.get("metric_special", metric_special)
+            # Resolve into new locals, not into metric/metric_special/
+            # metric_missing themselves -- overwriting those leaks this
+            # variable's override into every later variable (GH #355).
+            var_metric = params.get("metric", metric)
+            var_metric_missing = params.get("metric_missing", metric_missing)
+            var_metric_special = params.get("metric_special", metric_special)
 
             tparams = {
                 "x": x,
-                "metric": metric,
-                "metric_special": metric_special,
-                "metric_missing": metric_missing,
+                "metric": var_metric,
+                "metric_special": var_metric_special,
+                "metric_missing": var_metric_missing,
                 "check_input": check_input,
                 "show_digits": show_digits
                 }
@@ -1445,7 +1448,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
             if isinstance(optb, _OPTBPW_TYPES):
                 tparams.pop("show_digits")
 
-            if metric is None:
+            if var_metric is None:
                 tparams.pop("metric")
 
             X_transform[:, i] = optb.transform(**tparams)
@@ -1527,22 +1530,27 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                 if self.binning_transform_params is not None:
                     params = self.binning_transform_params.get(name, {})
 
-                metric = params.get("metric", metric)
-                metric_missing = params.get("metric_missing", metric_missing)
-                metric_special = params.get("metric_special", metric_special)
+                # Same fix as _transform() (GH #355) -- resolve into new
+                # locals so an override can't leak into the next variable
+                # or chunk.
+                var_metric = params.get("metric", metric)
+                var_metric_missing = params.get(
+                    "metric_missing", metric_missing)
+                var_metric_special = params.get(
+                    "metric_special", metric_special)
 
                 tparams = {
                     "x": chunk[name],
-                    "metric": metric,
-                    "metric_special": metric_special,
-                    "metric_missing": metric_missing,
+                    "metric": var_metric,
+                    "metric_special": var_metric_special,
+                    "metric_missing": var_metric_missing,
                     "show_digits": show_digits
                     }
 
                 if isinstance(optb, _OPTBPW_TYPES):
                     tparams.pop("show_digits")
 
-                if metric is None:
+                if var_metric is None:
                     tparams.pop("metric")
 
                 X_transform[:, i] = optb.transform(**tparams)

--- a/tests/test_binning_process.py
+++ b/tests/test_binning_process.py
@@ -495,6 +495,29 @@ def test_binning_transform_params():
         X_transform = process.fit_transform(X[:, :3], y)
 
 
+def test_binning_transform_params_no_leak():
+    # A per-variable override in binning_transform_params must not leak
+    # into the next variable's default. See GH #355.
+    X3 = X[:, :3].copy()
+    X3[:5, 1] = np.nan  # only variable_names[1] has missing values
+
+    btp = {variable_names[0]: {"metric_missing": 99.0}}
+
+    process = BinningProcess(variable_names[:3],
+                             binning_transform_params=btp)
+    process.fit(X3, y)
+    x_transform = process.transform(X3, metric="woe")
+
+    baseline = BinningProcess(variable_names[:3])
+    baseline.fit(X3, y)
+    x_transform_baseline = baseline.transform(X3, metric="woe")
+
+    # variable_names[1]'s missing rows must use the global default
+    # (metric_missing=0), not variable_names[0]'s 99.0 override.
+    assert x_transform[:5, 1] == approx(x_transform_baseline[:5, 1])
+    assert (x_transform[:5, 1] == 0).all()
+
+
 def test_update_binned_variable():
     process = BinningProcess(variable_names)
     process.fit(X, y, check_input=True)


### PR DESCRIPTION
Closes #355.

## Bug

`BinningProcess.transform()` (and its disk/chunked counterpart, `_transform_disk()`) resolved each variable's effective `metric`/`metric_special`/`metric_missing` by reassigning the function's own parameters in a loop:

    metric = params.get("metric", metric)
    metric_missing = params.get("metric_missing", metric_missing)
    metric_special = params.get("metric_special", metric_special)

Since `metric`/`metric_missing`/`metric_special` are the function's own arguments, this reassignment persists across loop iterations. Once one variable's `binning_transform_params` override was applied, it silently became the fallback default for every subsequent variable that had no override of its own -- exactly as reported: a `metric_missing` override meant for one variable leaked into the rest.

## Fix

Introduced separate `var_metric` / `var_metric_missing` / `var_metric_special` names for the per-variable resolved values, always falling back to the original call arguments rather than the previous iteration's resolved values. Applied identically to both `transform()` and `_transform_disk()`, which had the same bug.

## Testing

Added `test_binning_transform_params_no_leak`: fits on 3 variables with missing values only in the second, sets a distinctive `metric_missing` override only on the first variable, and confirms the second variable's transform output for its missing rows matches a baseline process with no `binning_transform_params` at all. Verified this test fails against the pre-fix code (reproduces the leak) and passes against the fix. Full suite passes locally with the same pre-existing failures as master; flake8 clean.