### PR TITLE
Fix AttributeError in ContinuousOptimalBinning when special codes are absent

### DIFF
--- a/optbinning/binning/binning_statistics.py
+++ b/optbinning/binning/binning_statistics.py
@@ -170,15 +170,12 @@ def target_info_special_continuous(special_codes, x, y, sw):
         n_records_special = []
         sum_special = []
         n_zeros_special = []
-
-        if len(y):
-            std_special = []
-            min_target_special = []
-            max_target_special = []
-        else:
-            std_special = None
-            min_target_special = None
-            max_target_special = None
+        # Must always start as lists, never None: the loop below calls
+        # .append() on these per special-code group regardless of
+        # whether any group is empty (GH #340).
+        std_special = []
+        min_target_special = []
+        max_target_special = []
 
         xt = pd.Series(x)
         for s in special_codes.values():

--- a/tests/test_continuous_binning.py
+++ b/tests/test_continuous_binning.py
@@ -277,3 +277,15 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def test_special_codes_dict_none_present():
+    # special_codes as a dict where none of the values occur in the
+    # data must not crash (GH #340: dict branch initialized the
+    # stat lists to None, then unconditionally .append()'d to them).
+    optb = ContinuousOptimalBinning(
+        name=variable, special_codes={'special': [-5, -6, -7, -9]})
+    optb.fit(x, y)
+
+    assert optb.status == "OPTIMAL"
+    optb.binning_table.build()


### PR DESCRIPTION
Closes #340.

## Bug

target_info_special_continuous()'s dict branch (in binning_statistics.py) initialized std_special/min_target_special/max_target_special to None whenever the special-value target array was empty, then unconditionally called .append() on them for every special-code group in the loop below -- raising AttributeError: 'NoneType' object has no attribute 'append'. This triggers whenever special_codes is configured as a dict but none of its values actually occur in the data, since the special-value target array (y_special) ends up empty in that case even though the loop over special_codes.values() still runs.

The non-dict branch a few lines below has the same-looking None-when-empty pattern, but it's correct there: that branch computes a single scalar via np.std/np.min/np.max, not a list built up by repeated .append() calls, so None is a valid final answer when there's no data. The dict branch's loop, unlike the non-dict path, already has its own per-group fallback (appending 0 when a specific special-code group has zero records), so there was never a valid reason for the list itself to start out as None.

## Fix

The three lists now always start as [] in the dict branch, never None, matching what bin_info() downstream already assumes (it branches on isinstance(n_records_special, list) and calls .extend() on all six lists together in that case).

## Testing

Added test_special_codes_dict_none_present to tests/test_continuous_binning.py: fits ContinuousOptimalBinning with special_codes as a dict whose values never occur in the data, confirming it no longer raises. Verified this reproduces the exact reported AttributeError against the pre-fix code and passes against the fix. Full suite passes locally with the same pre-existing failures as master; flake8 clean.