### PR TITLE
Fix record-count bugs in OptimalBinningSketch

### DIFF
--- a/optbinning/binning/distributed/binning_sketch.py
+++ b/optbinning/binning/distributed/binning_sketch.py
@@ -612,8 +612,15 @@ class OptimalBinningSketch(BaseSketch, BaseEstimator):
         time_postprocessing = time.perf_counter()
 
         if not len(splits):
-            n_nonevent = np.array([self._t_n_nonevent])
-            n_event = np.array([self._t_n_event])
+            # bin_info() below adds missing/special as separate bins, so
+            # this single "no splits" bin must exclude them too, or their
+            # counts get double-counted (GH #368).
+            n_nonevent = np.array([self._t_n_nonevent -
+                                   (self._n_nonevent_missing +
+                                    self._n_nonevent_special)])
+            n_event = np.array([self._t_n_event -
+                                (self._n_event_missing +
+                                 self._n_event_special)])
 
         self._n_nonevent, self._n_event = bin_info(
             self._solution, n_nonevent, n_event, self._n_nonevent_missing,

--- a/optbinning/binning/distributed/bsketch.py
+++ b/optbinning/binning/distributed/bsketch.py
@@ -184,11 +184,20 @@ class BSketch:
         if not self._mergeable(bsketch):
             raise Exception("bsketch does not share signature.")
 
+        # Merge missing/special counts before any early return: a
+        # batch of only missing/special records has empty regular
+        # sketches but real counts that must not be dropped (GH #368).
+        self._count_missing_e += bsketch._count_missing_e
+        self._count_missing_ne += bsketch._count_missing_ne
+        self._count_special_e += bsketch._count_special_e
+        self._count_special_ne += bsketch._count_special_ne
+
         if bsketch._sketch_e.n == 0 and bsketch._sketch_ne.n == 0:
             return
 
         if self._sketch_e.n == 0 and self._sketch_ne.n == 0:
-            self._copy(bsketch)
+            self._sketch_e = bsketch._sketch_e
+            self._sketch_ne = bsketch._sketch_ne
             return
 
         # Merge sketches
@@ -198,12 +207,6 @@ class BSketch:
         elif self.sketch == "t-digest":
             self._sketch_e += bsketch._sketch_e
             self._sketch_ne += bsketch._sketch_ne
-
-        # Merge missing and special counts
-        self._count_missing_e += bsketch._count_missing_e
-        self._count_missing_ne += bsketch._count_missing_ne
-        self._count_special_e += bsketch._count_special_e
-        self._count_special_ne += bsketch._count_special_ne
 
     def merge_sketches(self):
         """Merge event and non-event data internal sketches."""

--- a/tests/test_binning_sketch.py
+++ b/tests/test_binning_sketch.py
@@ -271,3 +271,43 @@ def test_verbose():
     optb.solve()
 
     assert optb.status == "OPTIMAL"
+
+
+def test_no_splits_missing_special_not_double_counted():
+    # When the optimizer finds no splits, missing and special record
+    # counts must not be folded into the (-inf, inf) bin's total on top
+    # of also being reported in their own separate rows -- otherwise the
+    # binning table's total record count is inflated. See GH issue #368.
+    x_small = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, -999.0, np.nan])
+    y_small = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0])
+
+    optb = OptimalBinningSketch(name="x", special_codes=[-999.0])
+    optb.add(x_small, y_small)
+    optb.solve()
+
+    assert len(optb.splits) == 0
+
+    table = optb.binning_table.build()
+    counts = table["Count"].values[:-1].astype(float)
+
+    assert counts[0] == 7  # (-inf, inf) bin: only the 7 regular records
+    assert counts.sum() == 9  # 7 regular + 1 special + 1 missing
+
+
+def test_merge_missing_special_only_batch():
+    # A batch that contains only missing and/or special records (no
+    # "regular" values at all) must not have its counts silently dropped
+    # when merged into another sketch. See GH issue #368.
+    optb1 = OptimalBinningSketch(name="x", special_codes=[-999.0])
+    optb1.add(np.array([1.0, 2.0, 3.0, 4.0]), np.array([0, 1, 0, 1]))
+
+    optb2 = OptimalBinningSketch(name="x", special_codes=[-999.0])
+    optb2.add(np.array([-999.0, np.nan]), np.array([1, 0]))
+
+    optb1.merge(optb2)
+    optb1.solve()
+
+    table = optb1.binning_table.build()
+    counts = table["Count"].values[:-1].astype(float)
+
+    assert counts.sum() == 6  # 4 regular + 1 special + 1 missing


### PR DESCRIPTION
Closes #368.

## Bug 1: missing/special double-counted when the optimizer finds no splits

In OptimalBinningSketch.solve() (binning_sketch.py), when len(splits) == 0 the single resulting bin's count was set from self._t_n_nonevent / self._t_n_event -- the TOTAL sketch counts, which already include missing and special records. bin_info() then unconditionally appends the missing/special counts again as their own separate rows, so with splits present the main bin(s) already exclude missing/special (they come from self._bsketch.bins(splits)), but in the no-splits shortcut they were counted twice: once folded into the single bin, once again in the Special/Missing rows.

Example from the issue (7 regular records, 1 special, 1 missing): before the fix, the (-inf, inf) bin reports Count=9 and the table Totals row reports 11, instead of 7 and 9.

## Bug 2: missing/special counts dropped when merging a batch that has no regular records

BSketch.merge() (bsketch.py) early-returned without merging anything when the incoming batch's regular sketches (_sketch_e/_sketch_ne) were both empty -- which silently discarded that batch's missing/special counts too, since a batch made up entirely of missing/special values has empty regular sketches by definition but still carries real missing/special data. Moved the missing/special count merge to happen unconditionally, before any of the early-return branches, and changed it to accumulate (+=) rather than the old _copy() path's plain assignment (=), since either side can already carry its own missing/special counts from a previous add()/merge() even while its regular sketches are empty.

## Testing

Added two regression tests to tests/test_binning_sketch.py: test_no_splits_missing_special_not_double_counted (reproduces the issue's exact 7/1/1 example, forcing a no-splits solution and checking the binning table's counts) and test_merge_missing_special_only_batch (merges a batch containing only special/missing values into a sketch with regular data, confirms the counts survive). Verified both fail against the pre-fix code with the exact symptoms described in the issue, and pass against the fix. Full suite passes locally with the same pre-existing failures as master; flake8 clean.