### PR TITLE
Fix Missing bin marker showing wrong value in binning_table.plot() when add_special=False

### DIFF
--- a/optbinning/binning/binning_statistics.py
+++ b/optbinning/binning/binning_statistics.py
@@ -778,7 +778,7 @@ class BinningTable:
                 handle_missing = mpatches.Patch(hatch="\\", alpha=0.1)
                 label_missing = "Bin missing"
 
-                ax2.plot(pos_missing, metric_values[pos_missing], marker="o",
+                ax2.plot(pos_missing, metric_values[-1], marker="o",
                          color="black")
 
             if add_special and add_missing:
@@ -1348,7 +1348,7 @@ class MulticlassBinningTable:
             label_missing = "Bin missing"
 
             for i, cl in enumerate(self.classes):
-                ax2.plot(pos_missing, metric_values[pos_missing, i],
+                ax2.plot(pos_missing, metric_values[-1, i],
                          marker="o", color=colors[i])
 
         if add_special and add_missing:
@@ -1858,7 +1858,7 @@ class ContinuousBinningTable:
                 handle_missing = mpatches.Patch(hatch="\\", alpha=0.1)
                 label_missing = "Bin missing"
 
-                ax2.plot(pos_missing, metric_values[pos_missing], marker="o",
+                ax2.plot(pos_missing, metric_values[-1], marker="o",
                          color="black")
 
             if add_special and add_missing:

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -5,6 +5,8 @@ OptimalBinning testing.
 # Guillermo Navas-Palencia <g.navas.palencia@gmail.com>
 # Copyright (C) 2020
 
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 
@@ -570,3 +572,56 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def _plot_missing_marker_value(table, **plot_kwargs):
+    # plot() shows/saves its figure internally, so intercept plt.savefig
+    # to read the marker off the live Axes first. The "Bin missing"
+    # marker is always the last single-point line plotted.
+    import matplotlib.pyplot as plt
+
+    captured = {}
+
+    def fake_savefig(*args, **kwargs):
+        ax2 = plt.gcf().axes[-1]
+        single_point_lines = [
+            line for line in ax2.get_lines() if len(line.get_xdata()) == 1]
+        captured["y"] = single_point_lines[-1].get_ydata()[0]
+
+    with mock.patch("matplotlib.pyplot.savefig", side_effect=fake_savefig):
+        table.plot(savefig="tests/results/_tmp_plot.png", **plot_kwargs)
+
+    return captured["y"]
+
+
+def test_plot_missing_metric_matches_regardless_of_add_special():
+    # See GH issue #376 / PR #377: pos_missing is a display position that
+    # shifts with add_special=False, but was used to index metric_values,
+    # whose special/missing entries stay at fixed trailing positions.
+    # The missing bin's plotted value must equal metric_values[-1]
+    # regardless of add_special.
+    x_local = x.copy()
+    y_local = y.copy()
+
+    # Special group: mostly event but not pure, so its WoE is nonzero
+    # and clearly different from the missing group below.
+    x_local[:30] = -999
+    y_local[:30] = np.array([1] * 25 + [0] * 5)
+
+    # Missing group: mostly non-event but not pure.
+    x_local[30:60] = np.nan
+    y_local[30:60] = np.array([0] * 25 + [1] * 5)
+
+    optb = OptimalBinning(name=variable, special_codes=[-999])
+    optb.fit(x_local, y_local)
+
+    table = optb.binning_table
+    table.build()
+
+    y_with_special = _plot_missing_marker_value(
+        table, metric="woe", add_special=True, add_missing=True)
+    y_without_special = _plot_missing_marker_value(
+        table, metric="woe", add_special=False, add_missing=True)
+
+    assert y_with_special == approx(table._woe[-1], rel=1e-6)
+    assert y_without_special == approx(table._woe[-1], rel=1e-6)

--- a/tests/test_continuous_binning.py
+++ b/tests/test_continuous_binning.py
@@ -5,6 +5,8 @@ ContinuousOptimalBinning testing.
 # Guillermo Navas-Palencia <g.navas.palencia@gmail.com>
 # Copyright (C) 2020
 
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 
@@ -277,3 +279,57 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def _plot_missing_marker_value(table, **plot_kwargs):
+    # plot() shows/saves its figure internally, so intercept plt.savefig
+    # to read the marker off the live Axes first. The "Bin missing"
+    # marker is always the last single-point line plotted.
+    import matplotlib.pyplot as plt
+
+    captured = {}
+
+    def fake_savefig(*args, **kwargs):
+        ax2 = plt.gcf().axes[-1]
+        single_point_lines = [
+            line for line in ax2.get_lines() if len(line.get_xdata()) == 1]
+        captured["y"] = single_point_lines[-1].get_ydata()[0]
+
+    with mock.patch("matplotlib.pyplot.savefig", side_effect=fake_savefig):
+        table.plot(savefig="tests/results/_tmp_plot.png", **plot_kwargs)
+
+    return captured["y"]
+
+
+def test_plot_missing_metric_matches_regardless_of_add_special():
+    # See GH issue #376 / PR #377: pos_missing is a display position that
+    # shifts with add_special=False, but was used to index metric_values,
+    # whose special/missing entries stay at fixed trailing positions.
+    # The missing bin's plotted value must equal metric_values[-1]
+    # regardless of add_special.
+    rng = np.random.RandomState(0)
+
+    x_local = x.copy()
+    y_local = x_local * 2 + rng.normal(size=len(x_local))
+
+    # Special group: forced to a distinctive mean.
+    x_local[:30] = -999
+    y_local[:30] = 100.0
+
+    # Missing group: forced to a distinctive, different mean.
+    x_local[30:60] = np.nan
+    y_local[30:60] = -50.0
+
+    optb = ContinuousOptimalBinning(name=variable, special_codes=[-999])
+    optb.fit(x_local, y_local)
+
+    table = optb.binning_table
+    table.build()
+
+    y_with_special = _plot_missing_marker_value(
+        table, metric="mean", add_special=True, add_missing=True)
+    y_without_special = _plot_missing_marker_value(
+        table, metric="mean", add_special=False, add_missing=True)
+
+    assert y_with_special == approx(table._mean[-1], rel=1e-6)
+    assert y_without_special == approx(table._mean[-1], rel=1e-6)

--- a/tests/test_multiclass_binning.py
+++ b/tests/test_multiclass_binning.py
@@ -5,6 +5,9 @@ MulticlassOptimalBinning testing.
 # Guillermo Navas-Palencia <g.navas.palencia@gmail.com>
 # Copyright (C) 2020
 
+from unittest import mock
+
+import numpy as np
 import pandas as pd
 
 from pytest import approx, raises
@@ -226,3 +229,59 @@ def test_verbose():
     optb.fit(x, y)
 
     assert optb.status == "OPTIMAL"
+
+
+def _plot_missing_marker_values(table, **plot_kwargs):
+    # plot() shows/saves its figure internally, so intercept plt.savefig
+    # to read the markers off the live Axes first. The "Bin missing"
+    # markers (one per class) are always the last single-point lines.
+    import matplotlib.pyplot as plt
+
+    captured = {}
+
+    def fake_savefig(*args, **kwargs):
+        ax2 = plt.gcf().axes[-1]
+        single_point_lines = [
+            line for line in ax2.get_lines() if len(line.get_xdata()) == 1]
+        n_classes = len(table.classes)
+        captured["y"] = [
+            line.get_ydata()[0] for line in single_point_lines[-n_classes:]]
+
+    with mock.patch("matplotlib.pyplot.savefig", side_effect=fake_savefig):
+        table.plot(savefig="tests/results/_tmp_plot.png", **plot_kwargs)
+
+    return captured["y"]
+
+
+def test_plot_missing_metric_matches_regardless_of_add_special():
+    # See GH issue #376 / PR #377: pos_missing is a display position that
+    # shifts with add_special=False, but was used to index metric_values
+    # (event rate per class), whose entries stay at fixed trailing
+    # positions. The missing bin's plotted per-class values must equal
+    # metric_values[-1] regardless of add_special.
+    x_local = x.copy()
+    y_local = y.copy()
+
+    # Special group: forced to class 0 only.
+    x_local[:20] = -999
+    y_local[:20] = 0
+
+    # Missing group: forced to class 2 only, clearly different from the
+    # special group above.
+    x_local[20:40] = np.nan
+    y_local[20:40] = 2
+
+    optb = MulticlassOptimalBinning(name=variable, special_codes=[-999])
+    optb.fit(x_local, y_local)
+
+    table = optb.binning_table
+    table.build()
+
+    y_with_special = _plot_missing_marker_values(
+        table, add_special=True, add_missing=True)
+    y_without_special = _plot_missing_marker_values(
+        table, add_special=False, add_missing=True)
+
+    assert y_with_special == approx(list(table._event_rate[-1]), rel=1e-6)
+    assert y_without_special == approx(
+        list(table._event_rate[-1]), rel=1e-6)


### PR DESCRIPTION
Fixes #376. Also resolves PR #377 (credit to @Danielwohlr for the original diagnosis and fix) — opening as a fresh PR from my fork since I can't push to that branch, and per Guillermo's two requests on #377 that were never addressed: this targets develop, and the sklearn check_array usage on develop is already up to date so nothing else was needed there.

Bug: binning_table.plot() computes pos_missing as a display bar position, which shifts when add_special=False hides the special bins. That position was reused to index into the underlying metric array (WoE/mean/event rate), which always keeps special and missing entries at fixed trailing positions regardless of what is displayed. With add_special=False and at least one special group present, the Missing bin marker plotted the special group's value instead of its own.

The original PR #377 only fixed this for BinningTable.plot() (binary case). This PR fixes the identical bug in all three plot() implementations: BinningTable, MulticlassBinningTable, and ContinuousBinningTable. Fix is to index with metric_values[-1] (or [-1, i] for the multiclass case), since the missing bin's value is always the last entry by construction.

Added a regression test to each of the three affected test files, asserting the plotted Missing marker value is identical regardless of add_special, and equals the true underlying value. Verified each test fails against the pre-fix code and passes after.