### PR TITLE
Fix Scorecard Points table ignoring per-variable metric_special/metric_missing overrides

### DIFF
--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -647,17 +647,30 @@ class Scorecard(Base, BaseEstimator):
             binning_table.loc[:, "Coefficient"] = c
             binning_table.loc[:, "Points"] = binning_table[bt_metric] * c
 
+            # Resolve per-variable metric_special/metric_missing overrides
+            # (fallback: the global fit() values), matching the resolution
+            # BinningProcess.transform() already used to build X_t (GH #380).
+            transform_params = {}
+            if self.binning_process_.binning_transform_params is not None:
+                transform_params = (
+                    self.binning_process_.binning_transform_params.get(
+                        variable, {}))
+            var_metric_special = transform_params.get(
+                'metric_special', metric_special)
+            var_metric_missing = transform_params.get(
+                'metric_missing', metric_missing)
+
             nt = len(binning_table)
-            if metric_special != 'empirical':
+            if var_metric_special != 'empirical':
                 if isinstance(optb.special_codes, dict):
                     n_specials = len(optb.special_codes)
                 else:
                     n_specials = 1
 
                 binning_table.loc[
-                    nt-1-n_specials:nt-2, "Points"] = metric_special * c
-            if metric_missing != 'empirical':
-                binning_table.loc[nt-1, "Points"] = metric_missing * c
+                    nt-1-n_specials:nt-2, "Points"] = var_metric_special * c
+            if var_metric_missing != 'empirical':
+                binning_table.loc[nt-1, "Points"] = var_metric_missing * c
 
             binning_table.index.names = ['Bin id']
             binning_table.reset_index(level=0, inplace=True)

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -484,3 +484,193 @@ def test_missing_metrics():
     ).fit(data, data.target)
 
     assert scorecard.table()['Points'].iloc[-1] == approx(0, rel=1e-6)
+
+
+def test_per_variable_metric_special():
+    # A variable's own binning_transform_params entry can override the
+    # global metric_special passed to Scorecard.fit(). The Points shown
+    # for that variable's "Special" bin(s) must reflect the per-variable
+    # override, not the global value. See GH issue #380 / PR #379.
+    data = load_breast_cancer()
+    variable_names = ['mean radius', 'mean texture', 'mean perimeter']
+    X = pd.DataFrame(data.data[:, :3], columns=variable_names)
+    y = data.target
+
+    X_with_specials = X.copy()
+    X_with_specials.loc[:20, 'mean radius'] = -999
+    X_with_specials.loc[:20, 'mean texture'] = -888
+
+    binning_process = BinningProcess(
+        variable_names=variable_names,
+        binning_fit_params={
+            'mean radius': {'special_codes': [-999]},
+            'mean texture': {'special_codes': [-888]},
+        },
+        binning_transform_params={
+            'mean radius': {'metric': 'woe', 'metric_special': 'empirical'},
+            'mean texture': {'metric': 'woe', 'metric_special': 0.5},
+            'mean perimeter': {'metric': 'woe'},
+        }
+    )
+
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(),
+    )
+
+    # Global metric_special=0 must be overridden per-variable below.
+    scorecard.fit(X_with_specials, y, metric_special=0)
+
+    table = scorecard.table(style='detailed')
+
+    radius_special = table[(table['Variable'] == 'mean radius') &
+                           (table['Bin'] == 'Special')]
+    texture_special = table[(table['Variable'] == 'mean texture') &
+                            (table['Bin'] == 'Special')]
+
+    assert len(radius_special) == 1
+    assert len(texture_special) == 1
+
+    # 'mean radius': metric_special='empirical' -> Points = WoE * coef.
+    woe_value = radius_special['WoE'].iloc[0]
+    coef_value = radius_special['Coefficient'].iloc[0]
+    assert radius_special['Points'].iloc[0] == approx(
+        woe_value * coef_value, rel=1e-6)
+
+    # 'mean texture': metric_special=0.5 -> Points = 0.5 * coef, and must
+    # NOT equal the global override (0) that would have applied pre-fix.
+    coef_value = texture_special['Coefficient'].iloc[0]
+    assert texture_special['Points'].iloc[0] == approx(
+        0.5 * coef_value, rel=1e-6)
+    assert texture_special['Points'].iloc[0] != approx(0, abs=1e-6)
+
+
+def test_per_variable_metric_special_backward_compatibility():
+    # A variable with no binning_transform_params entry at all must keep
+    # using the global metric_special, unaffected by this feature.
+    data = load_breast_cancer()
+    variable_names = ['mean radius', 'mean texture']
+    X = pd.DataFrame(data.data[:, :2], columns=variable_names)
+    y = data.target
+
+    X_with_specials = X.copy()
+    X_with_specials.loc[:20, 'mean radius'] = -999
+    X_with_specials.loc[:20, 'mean texture'] = -888
+
+    binning_process = BinningProcess(
+        variable_names=variable_names,
+        binning_fit_params={
+            'mean radius': {'special_codes': [-999]},
+            'mean texture': {'special_codes': [-888]},
+        },
+    )
+
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(),
+    )
+
+    scorecard.fit(X_with_specials, y, metric_special=0.3)
+
+    table = scorecard.table(style='detailed')
+
+    for variable in variable_names:
+        special_rows = table[(table['Variable'] == variable) &
+                             (table['Bin'] == 'Special')]
+        assert len(special_rows) == 1
+
+        coef_value = special_rows['Coefficient'].iloc[0]
+        assert special_rows['Points'].iloc[0] == approx(
+            0.3 * coef_value, rel=1e-6)
+
+
+def test_per_variable_metric_missing():
+    # Same as test_per_variable_metric_special but for metric_missing,
+    # using categorical variables (categorical_variables passed
+    # explicitly since dtype auto-detection misses string columns on
+    # newer pandas).
+    data = pd.DataFrame({
+        'target': np.hstack((np.tile(np.array([0, 1]), 50),
+                             np.array([0] * 90 + [1] * 10))),
+        'var1': [np.nan] * 100 + ['A'] * 100,
+        'var2': [np.nan] * 100 + ['B'] * 100,
+    })
+
+    binning_process = BinningProcess(
+        variable_names=['var1', 'var2'],
+        categorical_variables=['var1', 'var2'],
+        binning_transform_params={
+            'var1': {'metric': 'woe', 'metric_missing': 'empirical'},
+            'var2': {'metric': 'woe', 'metric_missing': 0.25},
+        }
+    )
+
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(),
+    )
+
+    # Global metric_missing=0 must be overridden per-variable below.
+    scorecard.fit(data[['var1', 'var2']], data.target, metric_missing=0)
+
+    table = scorecard.table(style='detailed')
+
+    var1_missing = table[(table['Variable'] == 'var1') &
+                         (table['Bin'] == 'Missing')]
+    var2_missing = table[(table['Variable'] == 'var2') &
+                         (table['Bin'] == 'Missing')]
+
+    assert len(var1_missing) == 1
+    assert len(var2_missing) == 1
+
+    # 'var1': metric_missing='empirical' -> Points = WoE * coef.
+    woe_value = var1_missing['WoE'].iloc[0]
+    coef_value = var1_missing['Coefficient'].iloc[0]
+    assert var1_missing['Points'].iloc[0] == approx(
+        woe_value * coef_value, rel=1e-6)
+
+    # 'var2': metric_missing=0.25 -> Points = 0.25 * coef, and must NOT
+    # equal the global override (0) that would have applied pre-fix.
+    coef_value = var2_missing['Coefficient'].iloc[0]
+    assert var2_missing['Points'].iloc[0] == approx(
+        0.25 * coef_value, rel=1e-6)
+    assert var2_missing['Points'].iloc[0] != approx(0, abs=1e-6)
+
+
+def test_woe_points_consistency():
+    # For every bin of a variable using metric_special='empirical', Points
+    # must equal WoE * Coefficient across the whole table, not just the
+    # regular bins -- i.e. the special bin's Points must be consistent
+    # with its own WoE once the per-variable override is respected.
+    data = load_breast_cancer()
+    variable_names = ['mean radius', 'mean texture']
+    X = pd.DataFrame(data.data[:, :2], columns=variable_names)
+    y = data.target
+
+    X_with_specials = X.copy()
+    X_with_specials.loc[:20, 'mean radius'] = -999
+
+    binning_process = BinningProcess(
+        variable_names=variable_names,
+        binning_fit_params={
+            'mean radius': {'special_codes': [-999]},
+        },
+        binning_transform_params={
+            'mean radius': {'metric': 'woe', 'metric_special': 'empirical'},
+        }
+    )
+
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(),
+    )
+
+    scorecard.fit(X_with_specials, y)
+
+    table = scorecard.table(style='detailed')
+    radius_table = table[table['Variable'] == 'mean radius']
+
+    assert len(radius_table) > 0
+    for _, row in radius_table.iterrows():
+        assert row['Points'] == approx(row['WoE'] * row['Coefficient'],
+                                       rel=1e-6)


### PR DESCRIPTION
Fixes #380. Also resolves PR #379 (credit to @niklasvm for the original design and implementation) — opening as a fresh PR from my fork since I can't push to that branch.

BinningProcess already supports per-variable metric_special/metric_missing overrides via binning_transform_params, so the WoE/mean values actually used to score samples were already correct. The gap: Scorecard._fit()'s table-building loop only read the global metric_special/metric_missing passed to fit(), never consulting binning_transform_params, so the Points shown for a variable's Special/Missing rows could silently disagree with what the model actually used to score that variable.

Fix resolves var_metric_special/var_metric_missing from binning_process_.binning_transform_params per variable, falling back to the global values, mirroring the resolution BinningProcess.transform() already does.

Guillermo noted PR #379's own tests were failing because a categorical column wasn't specified. Reproduced: BinningProcess's dtype auto-detection (x.dtype == object) doesn't reliably catch string columns on pandas 3+, which uses its own Arrow-backed string dtype by default instead of object. Fixed by declaring categorical_variables explicitly in the affected test. Same category as the already-known unrelated test_missing_metrics failure in this repo (not touched here, out of scope).

Rewrote the 4 tests with non-vacuous assertions (asserting the target row exists before checking its value) and verified each fails against the pre-fix code and passes after.