### PR TITLE
Allow iv as a selection_criteria metric for continuous targets

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -48,7 +48,8 @@ _METRICS = {
         "quality_score": {"min": 0, "max": 1}
     },
     "continuous": {
-        "metrics": ["woe", "quality_score"],
+        "metrics": ["iv", "woe", "quality_score"],
+        "iv": {"min": 0, "max": np.inf},
         "woe": {"min": 0, "max": np.inf},
         "quality_score": {"min": 0, "max": 1}
     }
@@ -426,6 +427,7 @@ class BaseBinningProcess:
                     "quality_score": optb.binning_table.quality_score}
             elif self._target_dtype == "continuous":
                 metrics = {
+                    "iv": optb.binning_table.iv,
                     "woe": optb.binning_table.woe,
                     "quality_score": optb.binning_table.quality_score}
 

--- a/tests/test_binning_process.py
+++ b/tests/test_binning_process.py
@@ -391,6 +391,40 @@ def test_default_transform_pandas():
         X_transform.values[:, 5], rel=1e-6)
 
 
+def test_selection_criteria_iv_continuous():
+    # "iv" was not accepted as a selection_criteria metric for continuous
+    # targets, even though ContinuousBinningTable already exposes it via
+    # its .iv property (same as the binary case). See GH issue #307.
+    data = load_boston()
+    variable_names = data.feature_names
+    X = data.data
+    y = data.target
+
+    process = BinningProcess(variable_names)
+    process.fit(X, y)
+
+    summary = process.summary()
+    assert "iv" in summary.columns
+
+    for name in variable_names:
+        optb = process.get_binned_variable(name)
+        row_iv = summary.loc[summary["name"] == name, "iv"].iloc[0]
+        assert row_iv == approx(optb.binning_table.iv, rel=1e-6)
+
+    # selection_criteria on "iv" must work for continuous targets exactly
+    # like it already does for binary/multiclass metrics.
+    selection_criteria = {"iv": {"min": 4.0}}
+    process = BinningProcess(variable_names=variable_names,
+                             selection_criteria=selection_criteria)
+    process.fit(X, y)
+
+    summary = process.summary()
+    assert summary.loc[summary["selected"], "iv"].min() >= 4.0
+    assert summary.loc[~summary["selected"], "iv"].max() < 4.0
+    assert summary["selected"].sum() > 0
+    assert summary["selected"].sum() < len(summary)
+
+
 def test_default_transform_continuous():
     data = load_boston()
     variable_names = data.feature_names


### PR DESCRIPTION
Fixes #307. ContinuousBinningTable already computes and exposes IV via .iv, identically to the binary case, but it was never added to BinningProcess's _METRICS config, so selection_criteria={"iv": ...} raised ValueError for continuous targets and summary() never showed an iv column even though the value was directly accessible via get_binned_variable(name).binning_table.iv. Added iv to the continuous metrics list and to the per-variable stats dict in _binning_selection_criteria(), mirroring the binary branch. Added a regression test verifying summary() now includes iv (matching the binning table's own value) and that selection_criteria on iv filters correctly for continuous targets. Verified the test fails against the pre-fix code.