### PR TITLE
Fix WoE/IV formula in continuous-target tutorial docs

### DIFF
--- a/doc/source/tutorials/tutorial_continuous.ipynb
+++ b/doc/source/tutorials/tutorial_continuous.ipynb
@@ -507,7 +507,7 @@
     "The WoE IV for a continuous target is computed as follows:\n",
     "\n",
     "\\begin{equation}\n",
-    "IV = \\sum_{i=1}^n \\text{WoE}_i \\frac{r_i}{r_T}, \\quad \\text{WoE}_i = |U_i - \\mu|,\n",
+    "IV = \\sum_{i=1}^n |\\text{WoE}_i| \\frac{r_i}{r_T}, \\quad \\text{WoE}_i = U_i - \\mu,\n",
     "\\end{equation}\n",
     "\n",
     "where $U_i$ is the target mean value for each bin, $\\mu$ is the total target mean, $r_i$ is the number of records for each bin, and $r_T$ is the total number of records.\n",


### PR DESCRIPTION
Fixes #370.

The tutorial notebook documented the continuous-target WoE/IV formula
with the absolute value in the wrong place:

    WoE_i = |U_i - mu|
    IV = sum_i WoE_i * (r_i / r_T)

As the issue reporter noted, the per-bin WoE should not have an absolute
value applied. Checking the actual implementation
(`ContinuousBinningTable.build()` in `binning_statistics.py`) confirms:

    woe = self._mean - t_mean          # no abs
    iv = np.absolute(woe) * p_records  # abs applied here

So this PR moves the abs from the WoE definition to the IV summation,
matching what the code actually computes:

    WoE_i = U_i - mu
    IV = sum_i |WoE_i| * (r_i / r_T)

Doc-only change (single line in tutorial_continuous.ipynb), no source
or tests touched.