### PR TITLE
Add target_dtype override to bypass type_of_target auto-detection

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -62,6 +62,33 @@ _OPTB_TYPES = (OptimalBinning, ContinuousOptimalBinning,
 _OPTBPW_TYPES = (OptimalPWBinning, ContinuousOptimalPWBinning)
 
 
+# type_of_target cannot tell an integer-valued continuous target (e.g.
+# sklearn.datasets.load_diabetes().target) from an integer-coded
+# classification target -- it always returns "multiclass" for both
+# (see GH issue #296). This is intentional sklearn behaviour, so
+# auto-detection is left as-is; target_dtype is the explicit override.
+def resolve_target_dtype(y, target_dtype=None):
+    """Determine the target type.
+
+    Parameters
+    ----------
+    y : array-like of shape (n_samples,)
+        Target vector.
+
+    target_dtype : str or None, default=None
+        If None, inferred via ``sklearn.utils.multiclass.type_of_target``.
+        Otherwise used directly, skipping inference (see GH issue #296).
+
+    Returns
+    -------
+    target_dtype : str
+    """
+    if target_dtype is not None:
+        return target_dtype
+
+    return type_of_target(y)
+
+
 def _read_column(input_path, extension, column, **kwargs):
     if extension == "csv":
         x = pd.read_csv(input_path, engine='c', usecols=[column],
@@ -203,7 +230,8 @@ def _check_parameters(variable_names, max_n_prebins, min_prebin_size,
                       max_pvalue, max_pvalue_policy, selection_criteria,
                       fixed_variables, categorical_variables, special_codes,
                       split_digits, binning_fit_params,
-                      binning_transform_params, n_jobs, verbose):
+                      binning_transform_params, target_dtype, n_jobs,
+                      verbose):
 
     if not isinstance(variable_names, (np.ndarray, list)):
         raise TypeError("variable_names must be a list or numpy.ndarray.")
@@ -298,6 +326,12 @@ def _check_parameters(variable_names, max_n_prebins, min_prebin_size,
     if binning_transform_params is not None:
         if not isinstance(binning_transform_params, dict):
             raise TypeError("binning_transform_params must be a dict.")
+
+    if target_dtype is not None:
+        if target_dtype not in ("binary", "continuous", "multiclass"):
+            raise ValueError('target_dtype must be "binary", "continuous", '
+                             '"multiclass" or None; got {}.'
+                             .format(target_dtype))
 
     if n_jobs is not None:
         if not isinstance(n_jobs, numbers.Integral):
@@ -510,6 +544,15 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         Dictionary with optimal binning transform options for specific
         variables. Example ``{"variable_1": {"metric": "event_rate"}}``.
 
+    target_dtype : str or None, optional (default=None)
+        The target type, one of "binary", "continuous" or "multiclass".
+        If None, inferred automatically via
+        ``sklearn.utils.multiclass.type_of_target``. Set explicitly to
+        override auto-detection, e.g. for an integer-valued continuous
+        target (see GH issue #296).
+
+        .. versionadded:: 0.21.0
+
     n_jobs : int or None, optional (default=None)
         Number of cores to run in parallel while binning variables.
         ``None`` means 1 core. ``-1`` means using all processors.
@@ -559,7 +602,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                  fixed_variables=None, categorical_variables=None,
                  special_codes=None, split_digits=None,
                  binning_fit_params=None, binning_transform_params=None,
-                 n_jobs=None, verbose=False):
+                 target_dtype=None, n_jobs=None, verbose=False):
 
         self.variable_names = variable_names
 
@@ -581,6 +624,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         self.special_codes = special_codes
         self.split_digits = split_digits
         self.categorical_variables = categorical_variables
+        self.target_dtype = target_dtype
         self.n_jobs = n_jobs
         self.verbose = verbose
 
@@ -1067,11 +1111,14 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
             raise TypeError("X must be a pandas.DataFrame or numpy.ndarray.")
 
         # check target dtype
-        self._target_dtype = type_of_target(y)
+        self._target_dtype = resolve_target_dtype(y, self.target_dtype)
 
         if self._target_dtype not in ("binary", "continuous", "multiclass"):
-            raise ValueError("Target type {} is not supported."
-                             .format(self._target_dtype))
+            raise ValueError(
+                "Target type {} is not supported. If auto-detection is "
+                "incorrect for your target (e.g. a continuous target with "
+                "integer values), pass target_dtype explicitly."
+                .format(self._target_dtype))
 
         # check sample weight
         if sample_weight is not None and self._target_dtype != "binary":
@@ -1211,11 +1258,14 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
 
         # Retrieve target and check dtype
         y = _read_column(input_path, extension, target, **kwargs)
-        self._target_dtype = type_of_target(y)
+        self._target_dtype = resolve_target_dtype(y, self.target_dtype)
 
         if self._target_dtype not in ("binary", "continuous", "multiclass"):
-            raise ValueError("Target type {} is not supported."
-                             .format(self._target_dtype))
+            raise ValueError(
+                "Target type {} is not supported. If auto-detection is "
+                "incorrect for your target (e.g. a continuous target with "
+                "integer values), pass target_dtype explicitly."
+                .format(self._target_dtype))
 
         if self.selection_criteria is not None:
             _check_selection_criteria(self.selection_criteria,

--- a/optbinning/scorecard/monitoring.py
+++ b/optbinning/scorecard/monitoring.py
@@ -16,7 +16,6 @@ import pandas as pd
 from scipy import stats
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.multiclass import type_of_target
 
 from ..binning.binning_statistics import bin_str_format
 from ..binning.metrics import jeffrey
@@ -256,22 +255,9 @@ class ScorecardMonitoring(BaseEstimator):
         # Check if scorecard is fitted
         self.scorecard._check_is_fitted()
 
-        target_dtype = type_of_target(y_actual)
-        target_dtype_e = type_of_target(y_expected)
-
-        if target_dtype not in ("binary", "continuous"):
-            raise ValueError("Target type (actual) {} is not supported."
-                             .format(target_dtype))
-
-        if target_dtype_e not in ("binary", "continuous"):
-            raise ValueError("Target type (expected) {} is not supported."
-                             .format(target_dtype_e))
-
-        if target_dtype != target_dtype_e:
-            raise ValueError("Target types must coincide; {} != {}."
-                             .format(target_dtype, target_dtype_e))
-
-        self._target_dtype = target_dtype
+        # Trust the already-fitted scorecard's own target type instead of
+        # re-inferring it from y_actual/y_expected (GH issue #296).
+        self._target_dtype = self.scorecard._target_dtype
 
         # Check variable names
         if list(X_actual.columns) != list(X_expected.columns):

--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -15,10 +15,10 @@ import pandas as pd
 
 from sklearn.base import BaseEstimator
 from sklearn.base import clone
-from sklearn.utils.multiclass import type_of_target
 
 from ..binning.base import Base
 from ..binning.binning_process import BinningProcess
+from ..binning.binning_process import resolve_target_dtype
 from ..logging import Logger
 from .rounding import RoundingMIP
 from .scorecard_information import print_scorecard_information
@@ -29,7 +29,7 @@ logger = Logger(__name__).logger
 
 def _check_parameters(binning_process, estimator, scaling_method,
                       scaling_method_params, intercept_based,
-                      reverse_scorecard, rounding, verbose):
+                      reverse_scorecard, rounding, target_dtype, verbose):
 
     if not isinstance(binning_process, BinningProcess):
         raise TypeError("binning_process must be a BinningProcess instance.")
@@ -64,6 +64,11 @@ def _check_parameters(binning_process, estimator, scaling_method,
     if rounding and scaling_method is None:
         raise ValueError("rounding is only applied if scaling method is "
                          "not None.")
+
+    if target_dtype is not None:
+        if target_dtype not in ("binary", "continuous"):
+            raise ValueError('target_dtype must be "binary", "continuous" '
+                             'or None; got {}.'.format(target_dtype))
 
     if not isinstance(verbose, bool):
         raise TypeError("verbose must be a boolean; got {}.".format(verbose))
@@ -215,6 +220,15 @@ class Scorecard(Base, BaseEstimator):
         minimum/maximum score after rounding. Otherwise, the scorecard points
         are round to the nearest integer.
 
+    target_dtype : str or None, optional (default=None)
+        The target type, one of "binary" or "continuous". If None,
+        inferred automatically via
+        ``sklearn.utils.multiclass.type_of_target``. Set explicitly to
+        override auto-detection, e.g. for an integer-valued continuous
+        target (see GH issue #296).
+
+        .. versionadded:: 0.21.0
+
     verbose : bool (default=False)
         Enable verbose output.
 
@@ -231,7 +245,8 @@ class Scorecard(Base, BaseEstimator):
     """
     def __init__(self, binning_process, estimator, scaling_method=None,
                  scaling_method_params=None, intercept_based=False,
-                 reverse_scorecard=False, rounding=False, verbose=False):
+                 reverse_scorecard=False, rounding=False, target_dtype=None,
+                 verbose=False):
 
         self.binning_process = binning_process
         self.estimator = estimator
@@ -240,6 +255,7 @@ class Scorecard(Base, BaseEstimator):
         self.intercept_based = intercept_based
         self.reverse_scorecard = reverse_scorecard
         self.rounding = rounding
+        self.target_dtype = target_dtype
         self.verbose = verbose
 
         # attributes
@@ -557,11 +573,14 @@ class Scorecard(Base, BaseEstimator):
             raise TypeError("X must be a pandas.DataFrame.")
 
         # Target type and metric
-        self._target_dtype = type_of_target(y)
+        self._target_dtype = resolve_target_dtype(y, self.target_dtype)
 
         if self._target_dtype not in ("binary", "continuous"):
-            raise ValueError("Target type {} is not supported."
-                             .format(self._target_dtype))
+            raise ValueError(
+                "Target type {} is not supported. If auto-detection is "
+                "incorrect for your target (e.g. a continuous target with "
+                "integer values), pass target_dtype explicitly."
+                .format(self._target_dtype))
 
         _check_scorecard_scaling(self.scaling_method,
                                  self.scaling_method_params,
@@ -591,6 +610,9 @@ class Scorecard(Base, BaseEstimator):
         self.binning_process_ = clone(self.binning_process)
         # Suppress binning process verbosity
         self.binning_process_.set_params(verbose=False)
+        # Propagate the resolved target type so the wrapped BinningProcess
+        # does not re-detect it independently (GH issue #296).
+        self.binning_process_.set_params(target_dtype=self._target_dtype)
 
         X_t = self.binning_process_.fit_transform(
             X[self.binning_process.variable_names], y, sample_weight, metric,

--- a/tests/test_binning_process.py
+++ b/tests/test_binning_process.py
@@ -20,9 +20,13 @@ from optbinning import ContinuousOptimalPWBinning
 from optbinning import MulticlassOptimalBinning
 from optbinning import OptimalBinning
 from optbinning import OptimalPWBinning
+from optbinning.binning.binning_process import _check_selection_criteria
+from optbinning.binning.binning_process import resolve_target_dtype
 from sklearn.datasets import load_breast_cancer
+from sklearn.datasets import load_diabetes
 from sklearn.datasets import load_wine
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.multiclass import type_of_target
 from tests.datasets import load_boston
 
 
@@ -389,6 +393,52 @@ def test_default_transform_pandas():
 
     assert optb.transform(x, metric="woe") == approx(
         X_transform.values[:, 5], rel=1e-6)
+
+
+def test_target_dtype_autodetect_unchanged():
+    # type_of_target classifies an integer-valued continuous target
+    # (e.g. load_diabetes().target) as "multiclass". Auto-detection
+    # (target_dtype=None) must stay exactly as sklearn provides it. See
+    # GH issue #296.
+    data = load_diabetes()
+    y = data.target
+
+    assert type_of_target(y) == "multiclass"
+    assert resolve_target_dtype(y) == "multiclass"
+
+    with raises(ValueError):
+        _check_selection_criteria({"woe": {"min": 0.01}}, "multiclass")
+
+
+def test_target_dtype_explicit_override():
+    # target_dtype overrides auto-detection entirely. See GH issue #296.
+    data = load_diabetes()
+    variable_names = data.feature_names
+    X = data.data
+    y = data.target
+
+    assert resolve_target_dtype(y, "continuous") == "continuous"
+
+    selection_criteria = {"woe": {"min": 0.01}}
+    process = BinningProcess(variable_names=variable_names,
+                             selection_criteria=selection_criteria,
+                             target_dtype="continuous")
+    process.fit(X, y)
+
+    assert process._target_dtype == "continuous"
+    summary = process.summary()
+    assert "woe" in summary.columns
+
+    # An integer-dtype target (e.g. load_wine()) is unaffected.
+    y_wine = load_wine().target
+    assert y_wine.dtype.kind == "i"
+    assert resolve_target_dtype(y_wine) == "multiclass"
+
+
+def test_target_dtype_invalid():
+    with raises(ValueError):
+        process = BinningProcess(variable_names=[], target_dtype="bad_value")
+        process.fit(X, y)
 
 
 def test_default_transform_continuous():

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -15,6 +15,7 @@ from contextlib import redirect_stdout
 from optbinning import BinningProcess
 from optbinning import Scorecard
 from sklearn.datasets import load_breast_cancer
+from sklearn.datasets import load_diabetes
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
@@ -208,6 +209,59 @@ def test_default_continuous():
 
     assert sc_min == approx(-43.261900687199045, rel=1e-6)
     assert sc_max == approx(100.28829019286185, rel=1e-6)
+
+
+def test_target_dtype_autodetect_unchanged():
+    # An integer-valued continuous target (e.g. load_diabetes().target)
+    # is classified "multiclass" by type_of_target, which Scorecard
+    # doesn't support, so fit() raises unless target_dtype is passed
+    # explicitly (see next test). See GH issue #296.
+    data = load_diabetes()
+    variable_names = data.feature_names
+    X = pd.DataFrame(data.data, columns=variable_names)
+    y = data.target
+
+    binning_process = BinningProcess(variable_names)
+    estimator = LinearRegression()
+
+    scorecard = Scorecard(binning_process=binning_process,
+                          estimator=estimator, scaling_method=None)
+
+    with raises(ValueError):
+        scorecard.fit(X, y)
+
+
+def test_target_dtype_explicit_override():
+    # target_dtype overrides auto-detection entirely. See GH issue #296.
+    data = load_diabetes()
+    variable_names = data.feature_names
+    X = pd.DataFrame(data.data, columns=variable_names)
+    y = data.target
+
+    binning_process = BinningProcess(variable_names)
+    estimator = LinearRegression()
+
+    scorecard = Scorecard(binning_process=binning_process,
+                          estimator=estimator, scaling_method=None,
+                          target_dtype="continuous")
+    scorecard.fit(X, y)
+
+    assert scorecard._target_dtype == "continuous"
+
+
+def test_target_dtype_invalid():
+    data = load_breast_cancer()
+    variable_names = data.feature_names
+    X = pd.DataFrame(data.data, columns=variable_names)
+    y = data.target
+
+    binning_process = BinningProcess(variable_names)
+    estimator = LogisticRegression()
+
+    with raises(ValueError):
+        scorecard = Scorecard(binning_process=binning_process,
+                              estimator=estimator, target_dtype="bad_value")
+        scorecard.fit(X, y)
 
 
 def test_scaling_method_pdo_odd():


### PR DESCRIPTION
Add target_dtype override in tests to bypass type_of_target auto-detection (fixes #296), that uses sklearn by default. 