### PR TITLE
Make variable_names optional in BinningProcess

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -205,8 +205,10 @@ def _check_parameters(variable_names, max_n_prebins, min_prebin_size,
                       split_digits, binning_fit_params,
                       binning_transform_params, n_jobs, verbose):
 
-    if not isinstance(variable_names, (np.ndarray, list)):
-        raise TypeError("variable_names must be a list or numpy.ndarray.")
+    if (variable_names is not None
+            and not isinstance(variable_names, (np.ndarray, list))):
+        raise TypeError("variable_names must be a list, numpy.ndarray or "
+                        "None.")
 
     if not isinstance(max_n_prebins, numbers.Integral) or max_n_prebins <= 1:
         raise ValueError("max_prebins must be an integer greater than 1; "
@@ -391,11 +393,11 @@ class BaseBinningProcess:
         # Fixed variables
         if self.fixed_variables is not None:
             for fv in self.fixed_variables:
-                idfv = list(self.variable_names).index(fv)
+                idfv = list(self._variable_names).index(fv)
                 self._support[idfv] = True
 
     def _binning_selection_criteria(self):
-        for i, name in enumerate(self.variable_names):
+        for i, name in enumerate(self._variable_names):
             optb = self._binned_variables[name]
             optb.binning_table.build()
 
@@ -441,8 +443,14 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
 
     Parameters
     ----------
-    variable_names : array-like
-        List of variable names.
+    variable_names : array-like or None, optional (default=None)
+        List of variable names. If None, names are inferred from ``X`` at
+        fit time: column names for a ``pandas.DataFrame``, or
+        ``"x0", "x1", ...`` for a ``numpy.ndarray``. Required (cannot be
+        None) when using ``fit_disk``.
+
+        .. versionchanged:: 0.21.0
+           ``variable_names`` is now optional.
 
     max_n_prebins : int (default=20)
         The maximum number of bins after pre-binning (prebins).
@@ -552,7 +560,8 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         option ``"solver": "mip"`` via the ``binning_fit_params`` parameter.
 
     """
-    def __init__(self, variable_names, max_n_prebins=20, min_prebin_size=0.05,
+    def __init__(self, variable_names=None, max_n_prebins=20,
+                 min_prebin_size=0.05,
                  min_n_bins=None, max_n_bins=None, min_bin_size=None,
                  max_bin_size=None, max_pvalue=None,
                  max_pvalue_policy="consecutive", selection_criteria=None,
@@ -587,6 +596,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         # auxiliary
         self._n_samples = None
         self._n_variables = None
+        self._variable_names = None
         self._target_dtype = None
         self._n_numerical = None
         self._n_categorical = None
@@ -954,7 +964,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         if not isinstance(name, str):
             raise TypeError("name must be a string.")
 
-        if name in self.variable_names:
+        if name in self._variable_names:
             return self._binned_variables[name]
         else:
             raise ValueError("name {} does not match a binned variable."
@@ -976,7 +986,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         if not isinstance(name, str):
             raise TypeError("name must be a string.")
 
-        if name not in self.variable_names:
+        if name not in self._variable_names:
             raise ValueError("name {} does not match a binned variable."
                              .format(name))
 
@@ -1049,7 +1059,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         if indices:
             return np.where(mask)[0]
         elif names:
-            return np.asarray(self.variable_names)[mask]
+            return np.asarray(self._variable_names)[mask]
         else:
             return mask
 
@@ -1094,7 +1104,16 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
 
         self._n_samples, self._n_variables = X.shape
 
-        if self._n_variables != len(self.variable_names):
+        if self.variable_names is None:
+            if isinstance(X, pd.DataFrame):
+                self._variable_names = list(X.columns)
+            else:
+                self._variable_names = ["x{}".format(i)
+                                        for i in range(self._n_variables)]
+        else:
+            self._variable_names = self.variable_names
+
+        if self._n_variables != len(self._variable_names):
             raise ValueError("The number of columns must be equal to the"
                              "length of variable_names.")
 
@@ -1113,7 +1132,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                         .format(n_jobs))
 
         if n_jobs == 1:
-            for i, name in enumerate(self.variable_names):
+            for i, name in enumerate(self._variable_names):
                 if self.verbose:
                     logger.info("Binning variable ({} / {}): {}."
                                 .format(i, self._n_variables, name))
@@ -1138,9 +1157,9 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                 self._variable_dtypes[name] = dtype
                 self._binned_variables[name] = optb
         else:
-            ids = np.arange(len(self.variable_names))
+            ids = np.arange(len(self._variable_names))
             id_blocks = np.array_split(ids, n_jobs)
-            names = np.asarray(self.variable_names)
+            names = np.asarray(self._variable_names)
 
             if isinstance(X, np.ndarray):
                 blocks = Parallel(n_jobs=n_jobs, prefer="threads")(
@@ -1197,6 +1216,13 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
 
         _check_parameters(**self.get_params())
 
+        # variable_names cannot be inferred from a file path; unlike fit(),
+        # fit_disk() requires it explicitly.
+        if self.variable_names is None:
+            raise ValueError("variable_names cannot be None when using "
+                             "fit_disk.")
+        self._variable_names = self.variable_names
+
         # Input file extension
         extension = input_path.split(".")[1]
 
@@ -1223,12 +1249,12 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
 
         if self.fixed_variables is not None:
             for fv in self.fixed_variables:
-                if fv not in self.variable_names:
+                if fv not in self._variable_names:
                     raise ValueError("Variable {} to be fixed is not a valid "
                                      "variable name.".format(fv))
 
         self._n_samples = len(y)
-        self._n_variables = len(self.variable_names)
+        self._n_variables = len(self._variable_names)
 
         if self.verbose:
             logger.info("Dataset: number of samples: {}."
@@ -1237,7 +1263,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
             logger.info("Dataset: number of variables: {}."
                         .format(self._n_variables))
 
-        for name in self.variable_names:
+        for name in self._variable_names:
             x = _read_column(input_path, extension, name, **kwargs)
 
             dtype, optb = _fit_variable(
@@ -1279,8 +1305,15 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
         if not isinstance(dict_optb, dict):
             raise TypeError("dict_optb must be a dict.")
 
+        # variable_names cannot be inferred here; unlike fit(), this
+        # method requires it explicitly.
+        if self.variable_names is None:
+            raise ValueError("variable_names cannot be None when using "
+                             "_fit_from_dict.")
+        self._variable_names = self.variable_names
+
         # Check variable names
-        if set(dict_optb.keys()) != set(self.variable_names):
+        if set(dict_optb.keys()) != set(self._variable_names):
             raise ValueError("dict_optb keys and variable names must "
                              "coincide.")
 
@@ -1326,7 +1359,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                                       self._target_dtype)
 
         self._n_samples = 0
-        self._n_variables = len(self.variable_names)
+        self._n_variables = len(self._variable_names)
 
         for name, optb in dict_optb.items():
             self._variable_dtypes[name] = optb.dtype
@@ -1394,7 +1427,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
                 metrics.add(metric)
 
             for idx in indices_selected_variables:
-                name = self.variable_names[idx]
+                name = self._variable_names[idx]
                 params = self.binning_transform_params.get(name, {})
                 metrics.add(params.get("metric", metric))
 
@@ -1417,7 +1450,7 @@ class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
             X_transform = np.zeros((n_samples, n_selected_variables))
 
         for i, idx in enumerate(indices_selected_variables):
-            name = self.variable_names[idx]
+            name = self._variable_names[idx]
             optb = self._binned_variables[name]
 
             if isinstance(X, np.ndarray):

--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -592,8 +592,15 @@ class Scorecard(Base, BaseEstimator):
         # Suppress binning process verbosity
         self.binning_process_.set_params(verbose=False)
 
+        # variable_names=None means "use all columns of X" (GH issue #343);
+        # only slice X when an explicit column subset was given.
+        if self.binning_process.variable_names is None:
+            X_bp = X
+        else:
+            X_bp = X[self.binning_process.variable_names]
+
         X_t = self.binning_process_.fit_transform(
-            X[self.binning_process.variable_names], y, sample_weight, metric,
+            X_bp, y, sample_weight, metric,
             metric_special, metric_missing, show_digits, check_input)
 
         self._time_binning_process = time.perf_counter() - time_binning_process
@@ -725,8 +732,11 @@ class Scorecard(Base, BaseEstimator):
     def _transform(self, X, metric, metric_special, metric_missing):
         self._check_is_fitted()
 
+        # binning_process_ is already fitted here, so its resolved
+        # _variable_names is always available (GH issue #343), unlike the
+        # possibly-None variable_names given at construction.
         X_t = self.binning_process_.transform(
-            X=X[self.binning_process_.variable_names], metric=metric,
+            X=X[self.binning_process_._variable_names], metric=metric,
             metric_special=metric_special, metric_missing=metric_missing)
 
         return X_t

--- a/tests/test_binning_process.py
+++ b/tests/test_binning_process.py
@@ -339,6 +339,41 @@ def test_categorical_variables():
         df_summary.name == "CHAS"]["dtype"].values[0] == "categorical"
 
 
+def test_variable_names_none_dataframe():
+    # variable_names=None infers column names from a DataFrame at fit time.
+    # See GH issue #343.
+    df = pd.DataFrame(data.data, columns=data.feature_names)
+
+    process = BinningProcess(variable_names=None)
+    process.fit(df, y)
+
+    assert process._variable_names == list(data.feature_names)
+
+    optb = process.get_binned_variable("mean radius")
+    assert optb.status == "OPTIMAL"
+
+
+def test_variable_names_none_array():
+    # variable_names=None with a plain ndarray falls back to x0, x1, ...
+    process = BinningProcess(variable_names=None)
+    process.fit(X, y)
+
+    expected = ["x{}".format(i) for i in range(X.shape[1])]
+    assert process._variable_names == expected
+
+    optb = process.get_binned_variable("x0")
+    assert optb.status == "OPTIMAL"
+
+
+def test_variable_names_none_disk():
+    # fit_disk cannot infer variable_names from a file path.
+    process = BinningProcess(variable_names=None)
+
+    with raises(ValueError):
+        process.fit_disk(input_path="tests/data/breast_cancer.csv",
+                         target="target")
+
+
 def test_fit_params():
     binning_fit_params = {"mean radius": {"max_n_bins": 4}}
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -210,6 +210,29 @@ def test_default_continuous():
     assert sc_max == approx(100.28829019286185, rel=1e-6)
 
 
+def test_binning_process_variable_names_none():
+    # Scorecard must work when its BinningProcess infers variable_names
+    # from X instead of receiving them explicitly. See GH issue #343.
+    data = load_breast_cancer()
+    X = pd.DataFrame(data.data, columns=data.feature_names)
+    y = data.target
+
+    binning_process = BinningProcess(variable_names=None)
+    estimator = LogisticRegression()
+
+    scorecard = Scorecard(binning_process=binning_process,
+                          estimator=estimator, scaling_method=None)
+    scorecard.fit(X, y)
+
+    assert scorecard.binning_process_._variable_names == list(X.columns)
+
+    X_t = scorecard.transform(X)
+    assert X_t.shape == X.shape
+
+    table = scorecard.table()
+    assert len(table) > 0
+
+
 def test_scaling_method_pdo_odd():
     data = load_breast_cancer()
     variable_names = data.feature_names


### PR DESCRIPTION
Implements the first of three paths discussed in #343: variable_names is now optional. When omitted, BinningProcess infers column names from a pandas DataFrame at fit time, or falls back to x0, x1, ... for a plain ndarray. fit_disk still requires it explicitly since it can't be inferred from a file path.

Scorecard is updated to handle a None variable_names correctly when driving its internal BinningProcess.

Closes part of #343.