### PR TITLE
Make BinningProcess a proper sklearn TransformerMixin

### DIFF
--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from joblib import Parallel, delayed, effective_n_jobs
 from sklearn.base import BaseEstimator
+from sklearn.base import TransformerMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils import check_array
 from sklearn.utils import check_consistent_length
@@ -435,7 +436,8 @@ class BaseBinningProcess:
         self._support_selection_criteria()
 
 
-class BinningProcess(Base, BaseEstimator, BaseBinningProcess):
+class BinningProcess(Base, TransformerMixin, BaseEstimator,
+                     BaseBinningProcess):
     """Binning process to compute optimal binning of variables in a dataset,
     given a binary, continuous or multiclass target dtype.
 

--- a/tests/test_binning_process.py
+++ b/tests/test_binning_process.py
@@ -20,9 +20,12 @@ from optbinning import ContinuousOptimalPWBinning
 from optbinning import MulticlassOptimalBinning
 from optbinning import OptimalBinning
 from optbinning import OptimalPWBinning
+from sklearn.base import TransformerMixin, clone
 from sklearn.datasets import load_breast_cancer
 from sklearn.datasets import load_wine
 from sklearn.exceptions import NotFittedError
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
 from tests.datasets import load_boston
 
 
@@ -337,6 +340,29 @@ def test_categorical_variables():
     df_summary = process.summary()
     assert df_summary[
         df_summary.name == "CHAS"]["dtype"].values[0] == "categorical"
+
+
+def test_transformer_mixin():
+    # BinningProcess is a proper sklearn TransformerMixin. See GH issue #343.
+    assert isinstance(BinningProcess(variable_names), TransformerMixin)
+
+    process = BinningProcess(variable_names)
+
+    # fit_transform keeps its own richer signature (metric, sample_weight),
+    # not TransformerMixin's naive fit(X, y).transform(X) default.
+    Xt = process.fit_transform(X, y, metric="woe")
+    assert Xt.shape == X.shape
+
+    # clone/get_params/set_params still work with the mixin added.
+    process2 = clone(process)
+    assert list(process2.get_params()["variable_names"]) == list(
+        variable_names)
+
+    # works as a Pipeline step
+    pipe = Pipeline([("bp", BinningProcess(variable_names)),
+                     ("clf", LogisticRegression())])
+    pipe.fit(X, y)
+    assert pipe.predict(X).shape == (X.shape[0],)
 
 
 def test_fit_params():


### PR DESCRIPTION
Implements the second of three paths discussed in #343: BinningProcess now subclasses sklearn.base.TransformerMixin.

BinningProcess already defines its own transform() and fit_transform(), so this is purely additive — it doesn't change existing behavior, it just makes BinningProcess pass isinstance(obj, TransformerMixin) checks and lets it participate correctly in sklearn.pipeline.Pipeline and other tooling that inspects for that marker.

Closes part of #343.