### PR TITLE
Remove debug print and narrow bare except in convex hull code

### DIFF
--- a/optbinning/binning/auto_monotonic.py
+++ b/optbinning/binning/auto_monotonic.py
@@ -8,6 +8,7 @@ Automatic monotonic trend algorithm.
 import numpy as np
 
 from scipy.spatial import ConvexHull
+from scipy.spatial import QhullError
 
 
 def n_peaks_valleys(x):
@@ -128,7 +129,7 @@ def auto_monotonic_data(n_nonevent, n_event):
         try:
             hull = ConvexHull(points)
             p_convex_hull = hull.volume / rectangular_area
-        except:
+        except QhullError:
             p_convex_hull = 0
     else:
         p_convex_hull = 0
@@ -201,7 +202,7 @@ def auto_monotonic_data_continuous(n_records, sums):
         try:
             hull = ConvexHull(points)
             p_convex_hull = hull.volume / rectangular_area
-        except:
+        except QhullError:
             p_convex_hull = 0
     else:
         p_convex_hull = 0

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -877,7 +877,6 @@ class ContinuousOptimalBinning(OptimalBinning):
 
         if len(y_others):
             if len(sw_others):
-                print(y_others.dtype, sw_others.dtype)
                 y_others = y_others * sw_others
 
             self._n_records_cat_others = np.sum(sw_others)


### PR DESCRIPTION
Two small, unrelated cleanups flagged in #403:

- Removes a leftover debug `print(y_others.dtype, sw_others.dtype)` in `ContinuousOptimalBinning._prebinning_refinement` (continuous_binning.py) that fired on every fit whenever `sw_others` was non-empty.
- Narrows the two bare `except:` around `ConvexHull()` calls in `auto_monotonic.py` to `except QhullError:`, the actual exception scipy raises for degenerate point sets (e.g. collinear points).

Verified the narrowed except still catches the real degenerate case (tested with collinear points), ran the full continuous/binning test suite plus all monotonic/multiclass tests — all pass, flake8 clean on both changed files.

Fixes #403.