### PR TITLE
Silence RuntimeWarning in transform_event_rate_to_woe

### DIFF
--- a/optbinning/binning/transformations.py
+++ b/optbinning/binning/transformations.py
@@ -35,7 +35,11 @@ def transform_event_rate_to_woe(event_rate, n_nonevent, n_event):
     woe : numpy.ndarray or float
         Weight of evidence.
     """
-    return np.log((1. / event_rate - 1) * n_event / n_nonevent)
+    # event_rate of 0 or 1 is a legitimate (pure) bin, not an error; it
+    # only yields +/-inf WoE, which is the correct value. Silence the
+    # resulting RuntimeWarning instead of the underlying computation.
+    with np.errstate(invalid='ignore'):
+        return np.log((1. / event_rate - 1) * n_event / n_nonevent)
 
 
 def transform_woe_to_event_rate(woe, n_nonevent, n_event):


### PR DESCRIPTION
Small fix for #353: wraps the log computation in `transform_event_rate_to_woe` (optbinning/binning/transformations.py) in `np.errstate(invalid='ignore')`.

An event_rate outside (0, 1) produces a `nan` WoE, which is the correct/expected value, not an error -- but numpy still emits `RuntimeWarning: invalid value encountered in log` every time. This silences the warning without changing any computed value.

Verified: reproduced the exact warning with an out-of-range event_rate, confirmed it's silenced post-fix with the same (nan) result returned; ran the binning/continuous_binning/multiclass_binning/binning_process test suites (63 passed, no regressions); flake8 clean.

Fixes #353.