### PR TITLE
Expose Wald-test p-values for Scorecard's explanatory variables

### DIFF
--- a/fix_pr408_conflicts.sh
+++ b/fix_pr408_conflicts.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Fixes the two real conflicts #408 (fix-224-scorecard-pvalues) had with
+# #395 and #398, both in scorecard.py / test_scorecard.py -- by moving
+# where #408 inserts its new code and its new test, same trick as the
+# #390 destack: the content doesn't change, just where it lands, so it
+# stops landing on the same lines #395/#398 also touch.
+#
+# Verified with real `git merge` trials: #395x#408 and #398x#408 both
+# merge with zero conflicts now, in either order, plus the full test
+# suite on the merged results.
+#
+# This only touches fix-224-scorecard-pvalues. No other branches are
+# affected.
+#
+# Run from your own terminal, same as the other scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+STARTING_BRANCH="$(git branch --show-current)"
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  echo "ERROR: you have uncommitted changes to tracked files. Commit or stash them first, then re-run." >&2
+  exit 1
+fi
+
+echo "Fetching latest from origin..."
+git fetch -q origin
+
+restore_branch() {
+  echo ""
+  echo "Restoring your original branch: $STARTING_BRANCH"
+  git checkout -q "$STARTING_BRANCH"
+}
+trap restore_branch EXIT
+
+BRANCH="fix-224-scorecard-pvalues"
+PATCH_FILE=$(mktemp)
+cat > "$PATCH_FILE" << 'PATCH_EOF_pr_408_fix'
+diff --git a/optbinning/scorecard/scorecard.py b/optbinning/scorecard/scorecard.py
+index d3d960d..e300b44 100644
+--- a/optbinning/scorecard/scorecard.py
++++ b/optbinning/scorecard/scorecard.py
+@@ -14,10 +14,10 @@ import numpy as np
+ import pandas as pd
+ 
+ from scipy import stats
++from sklearn.linear_model import LogisticRegression
+ 
+ from sklearn.base import BaseEstimator
+ from sklearn.base import clone
+-from sklearn.linear_model import LogisticRegression
+ from sklearn.utils.multiclass import type_of_target
+ 
+ from ..binning.base import Base
+@@ -736,12 +736,6 @@ class Scorecard(Base, BaseEstimator):
+             binning_table.loc[:, "Coefficient"] = c
+             binning_table.loc[:, "Points"] = binning_table[bt_metric] * c
+ 
+-            if pvalue_stats is not None:
+-                se, z, pvalues = pvalue_stats
+-                binning_table.loc[:, "Std. Error"] = se[i]
+-                binning_table.loc[:, "Z-score"] = z[i]
+-                binning_table.loc[:, "P-value"] = pvalues[i]
+-
+             nt = len(binning_table)
+             if metric_special != 'empirical':
+                 if isinstance(optb.special_codes, dict):
+@@ -756,6 +750,13 @@ class Scorecard(Base, BaseEstimator):
+ 
+             binning_table.index.names = ['Bin id']
+             binning_table.reset_index(level=0, inplace=True)
++
++            if pvalue_stats is not None:
++                se, z, pvalues = pvalue_stats
++                binning_table.loc[:, "Std. Error"] = se[i]
++                binning_table.loc[:, "Z-score"] = z[i]
++                binning_table.loc[:, "P-value"] = pvalues[i]
++
+             binning_tables.append(binning_table)
+ 
+         df_scorecard = pd.concat(binning_tables)
+diff --git a/tests/test_scorecard.py b/tests/test_scorecard.py
+index 44b4382..82b2119 100644
+--- a/tests/test_scorecard.py
++++ b/tests/test_scorecard.py
+@@ -463,29 +463,6 @@ def test_verbose():
+             scorecard.fit(X, y)
+ 
+ 
+-def test_missing_metrics():
+-    data = pd.DataFrame(
+-        {'target': np.hstack(
+-            (np.tile(np.array([0, 1]), 50),
+-             np.array([0]*90 + [1]*10)
+-             )
+-         ),
+-         'var': [np.nan] * 100 + ['A'] * 100}
+-    )
+-
+-    binning_process = BinningProcess(['var'])
+-    scaling_method_params = {'min': 0, 'max': 100}
+-
+-    scorecard = Scorecard(
+-        binning_process=binning_process,
+-        estimator=LogisticRegression(),
+-        scaling_method="min_max",
+-        scaling_method_params=scaling_method_params
+-    ).fit(data, data.target)
+-
+-    assert scorecard.table()['Points'].iloc[-1] == approx(0, rel=1e-6)
+-
+-
+ def test_pvalues():
+     # Scorecard.table(style="detailed") exposes Wald-test p-values for
+     # each explanatory variable when the estimator is a LogisticRegression
+@@ -553,3 +530,26 @@ def test_pvalues():
+         estimator=LinearRegression(),
+         scaling_method=None).fit(X, y_cont)
+     assert "P-value" not in scorecard_cont.table(style="detailed").columns
++
++
++def test_missing_metrics():
++    data = pd.DataFrame(
++        {'target': np.hstack(
++            (np.tile(np.array([0, 1]), 50),
++             np.array([0]*90 + [1]*10)
++             )
++         ),
++         'var': [np.nan] * 100 + ['A'] * 100}
++    )
++
++    binning_process = BinningProcess(['var'])
++    scaling_method_params = {'min': 0, 'max': 100}
++
++    scorecard = Scorecard(
++        binning_process=binning_process,
++        estimator=LogisticRegression(),
++        scaling_method="min_max",
++        scaling_method_params=scaling_method_params
++    ).fit(data, data.target)
++
++    assert scorecard.table()['Points'].iloc[-1] == approx(0, rel=1e-6)
+PATCH_EOF_pr_408_fix
+
+echo ""
+echo "=== $BRANCH ==="
+git checkout -q "$BRANCH"
+git reset -q --hard "origin/$BRANCH"
+if ! git apply --check "$PATCH_FILE" 2>/tmp/_pr408_apply_err; then
+  echo "  ERROR: patch does not apply cleanly (branch may have changed upstream since this was prepared)." >&2
+  cat /tmp/_pr408_apply_err >&2
+  exit 1
+fi
+git apply "$PATCH_FILE"
+git add -A -- ':!tests/results'
+git commit -q --amend --no-edit
+git push --force-with-lease origin "$BRANCH"
+echo "  OK: $BRANCH conflicts resolved and pushed"
+
+echo ""
+echo "All done."

--- a/optbinning/scorecard/scorecard.py
+++ b/optbinning/scorecard/scorecard.py
@@ -13,6 +13,9 @@ import time
 import numpy as np
 import pandas as pd
 
+from scipy import stats
+from sklearn.linear_model import LogisticRegression
+
 from sklearn.base import BaseEstimator
 from sklearn.base import clone
 from sklearn.utils.multiclass import type_of_target
@@ -172,6 +175,82 @@ def _compute_intercept_based(df_scorecard):
         intercept += min_point
 
     return scaled_points, intercept
+
+
+def _resolve_penalty(estimator):
+    """The effective regularization penalty of a ``LogisticRegression``.
+
+    scikit-learn >= 1.8 deprecated the ``penalty`` constructor argument
+    in favor of ``l1_ratio`` (0 = L2, 1 = L1, in between = elastic-net),
+    but ``penalty`` remains authoritative for backward compatibility
+    when the caller sets it explicitly rather than leaving it at its
+    ``"deprecated"`` sentinel default.
+    """
+    penalty = getattr(estimator, "penalty", "l2")
+
+    if penalty in (None, "l1", "l2", "elasticnet"):
+        return penalty
+
+    l1_ratio = getattr(estimator, "l1_ratio", None)
+    if l1_ratio is None or l1_ratio == 0:
+        return "l2"
+    elif l1_ratio == 1:
+        return "l1"
+    else:
+        return "elasticnet"
+
+
+def _wald_pvalues(estimator, X, y, coefs, intercept, sample_weight=None):
+    """Wald test standard errors, z-scores and p-values for a fitted
+    binary ``LogisticRegression``.
+
+    Only defined for no penalty or an L2 penalty: L1/elastic-net have no
+    closed-form covariance matrix, so ``None`` is returned for those
+    instead of a misleading number (GH issue #224). With an L2 penalty,
+    the p-values are an approximation, since shrinkage biases the fit
+    toward "not significant" relative to an unregularized estimate.
+    """
+    penalty = _resolve_penalty(estimator)
+
+    if penalty in ("l1", "elasticnet"):
+        logger.warning(
+            "p-values are not available: the estimator's %s penalty "
+            "has no closed-form covariance matrix. Use an L2-penalized "
+            "or unregularized LogisticRegression to obtain p-values.",
+            penalty)
+        return None
+
+    p = estimator.predict_proba(X)[:, 1]
+    w = p * (1 - p)
+    if sample_weight is not None:
+        w = w * sample_weight
+
+    x = np.asarray(X)
+    x_design = np.column_stack([np.ones(len(x)), x])
+    hessian = x_design.T @ (x_design * w[:, np.newaxis])
+
+    if penalty == "l2":
+        # Ridge-penalized Hessian of the negative log-likelihood; the
+        # intercept is not penalized, matching scikit-learn's own
+        # convention.
+        n_features = x_design.shape[1] - 1
+        hessian[1:, 1:] += np.eye(n_features) / estimator.C
+
+    try:
+        cov = np.linalg.inv(hessian)
+    except np.linalg.LinAlgError:
+        logger.warning("p-values are not available: the Hessian of the "
+                       "fitted model is singular.")
+        return None
+
+    se = np.sqrt(np.diag(cov))
+    # self.estimator_.intercept_ is a shape-(1,) array, not a scalar
+    beta = np.concatenate([np.ravel(intercept), coefs])
+    z = beta / se
+    pvalues = 2 * (1 - stats.norm.cdf(np.abs(z)))
+
+    # first entry is the intercept; the rest align 1-1 with coefs
+    return se[1:], z[1:], pvalues[1:]
 
 
 class Scorecard(Base, BaseEstimator):
@@ -630,6 +709,16 @@ class Scorecard(Base, BaseEstimator):
             raise RuntimeError('The classifier does not expose '
                                '"coef_" attribute.')
 
+        # p-values of the explanatory variables (GH issue #224), only
+        # meaningful for a binary target fitted with LogisticRegression --
+        # any other estimator's objective does not correspond to this
+        # covariance formula.
+        pvalue_stats = None
+        if (self._target_dtype == "binary"
+                and isinstance(self.estimator_, LogisticRegression)):
+            pvalue_stats = _wald_pvalues(
+                self.estimator_, X_t, y, coefs, intercept, sample_weight)
+
         # Build scorecard
         time_build_scorecard = time.perf_counter()
 
@@ -661,6 +750,13 @@ class Scorecard(Base, BaseEstimator):
 
             binning_table.index.names = ['Bin id']
             binning_table.reset_index(level=0, inplace=True)
+
+            if pvalue_stats is not None:
+                se, z, pvalues = pvalue_stats
+                binning_table.loc[:, "Std. Error"] = se[i]
+                binning_table.loc[:, "Z-score"] = z[i]
+                binning_table.loc[:, "P-value"] = pvalues[i]
+
             binning_tables.append(binning_table)
 
         df_scorecard = pd.concat(binning_tables)

--- a/pr-375-comment.md
+++ b/pr-375-comment.md
@@ -1,0 +1,24 @@
+Hi Guillermo — I've opened a batch of PRs against several of the open issues (mine and a few related ones I ran into along the way): #389, #390, #391, #392, #393, #394, #395, #396, #397, #398, #401, #402, #405, #406, #407, #408, #409.
+
+Since several of them touch the same few files, I test-merged all of them against each other locally (actual `git merge` trials for every pair, not just eyeballing diffs) to see where they'd actually conflict, in case it's useful for deciding review/merge order. Happy to rebase/adjust on my end wherever it helps rather than leaving it to GitHub's conflict UI.
+
+Two things I found and already fixed on my end, no action needed from you:
+- #390 was originally branched off #389, so its diff was temporarily showing #389's fix duplicated. Rebased it onto master directly and moved where its new tests get inserted — merges cleanly against #389 now, either order.
+- #395 and #408 both added code right after the same line in `Scorecard._fit()` (plus a smaller import-line overlap with #398). Moved where #408 inserts its block/import/test — no code changed, just relocated — so both now merge clean against #395 and #398 in either order.
+
+What's left, from the full pairwise scan (every one of the 136 possible pairs tested): 12 conflicting pairs, all of them the same trivial pattern — two PRs independently appending a new test (or import) at the same anchor line in a shared test file. None of them touch source code or change behavior either way; each is a few seconds with GitHub's "keep both changes" button. They cluster in two spots:
+
+1. `tests/test_binning.py` / `test_continuous_binning.py` / `test_multiclass_binning.py` — #389, #390, #392, #394, #407 all append tests near the end of these files, so most pairs among those five will show a conflict when merged one after another.
+2. `tests/test_binning_process.py` / `test_scorecard.py` — #396, #398, #401, #402 have the same pattern, more scattered (#398 conflicts with each of the other three; #401×#402 also conflicts).
+
+Suggested order, front-loading what's conflict-free:
+
+1. **#391, #393, #395, #397, #405, #406, #408, #409** — clean against everything else, any order.
+2. **#389, #390, #392, #394, #407** — work through these one at a time; each new one will likely flag a trivial "both added a test here" conflict against one or two of the earlier ones in this group — keep both.
+3. **#396, #398, #401, #402** — same story, #398 is the one that overlaps with each of the other three.
+
+If you'd rather I clean these up preemptively instead of you hitting them in the UI, say the word and I'll go relocate the remaining test insertions the same way I did for #390/#395/#408 above — it's a well-worn pattern at this point. Otherwise I'll leave them as-is since they're genuinely trivial either way.
+
+One correctness issue worth flagging separately (not a git conflict, so it won't show up anywhere in GitHub's UI): #409 renames the internal resolved-dtype attribute from `self.dtype` to `self._dtype`. #389's `read_json()` restores the other post-fit attributes needed for `transform()` to work after a reload, but was naturally written before `self._dtype` existed, so once both are merged, `transform()` on a `read_json()`-reloaded object will silently return wrong values instead of erroring (`self._dtype` stays `None`). I can't fix this as part of either PR alone since it only exists once both are on master — happy to submit a two-line follow-up (`self._dtype = bin_table_attr['dtype']` in `read_json()`, `binning.py` and `continuous_binning.py`) right after both land, unless you'd rather fold it into #389 or #409 directly during review.
+
+No pressure on the order above — just sharing what I found so you're not rediscovering it PR by PR. Let me know if you'd like me to combine or split any of these differently, or if it'd be easier for you if I merged some of the smaller/related ones into a single PR.

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -463,6 +463,75 @@ def test_verbose():
             scorecard.fit(X, y)
 
 
+def test_pvalues():
+    # Scorecard.table(style="detailed") exposes Wald-test p-values for
+    # each explanatory variable when the estimator is a LogisticRegression
+    # with no penalty or an L2 penalty. See GH issue #224.
+    data = load_breast_cancer()
+    X = pd.DataFrame(data.data[:, :5], columns=data.feature_names[:5])
+    y = data.target
+
+    binning_process = BinningProcess(variable_names=list(X.columns))
+    scorecard = Scorecard(
+        binning_process=binning_process,
+        estimator=LogisticRegression(penalty=None, max_iter=2000),
+        scaling_method=None).fit(X, y)
+
+    detailed = scorecard.table(style="detailed")
+    assert "P-value" in detailed.columns
+    assert "Std. Error" in detailed.columns
+    assert "Z-score" in detailed.columns
+
+    # p-values are per-variable, not per-bin -- constant within a variable
+    pvalues = detailed.groupby("Variable")["P-value"].nunique()
+    assert (pvalues == 1).all()
+
+    # a known-significant variable in this reduced feature set
+    pvalue_by_var = detailed.groupby("Variable")["P-value"].first()
+    assert pvalue_by_var["mean texture"] < 0.01
+
+    # cross-check against the classical Wald test computed independently
+    # (statsmodels is not a dependency; this recomputes the same formula
+    # directly instead of importing it)
+    from scipy import stats as scipy_stats
+    X_t = scorecard.binning_process_.transform(X, metric="woe")
+    x_design = np.column_stack([np.ones(len(X_t)), X_t.values])
+    clf = scorecard.estimator_
+    p = clf.predict_proba(X_t)[:, 1]
+    w = p * (1 - p)
+    hessian = x_design.T @ (x_design * w[:, np.newaxis])
+    se = np.sqrt(np.diag(np.linalg.inv(hessian)))
+    beta = np.concatenate([np.ravel(clf.intercept_), clf.coef_.flatten()])
+    expected_pvalues = 2 * (1 - scipy_stats.norm.cdf(np.abs(beta / se)))
+    # align by variable name: X_t's column order (fit/selection order) may
+    # differ from groupby's alphabetically-sorted order
+    expected_by_var = pd.Series(expected_pvalues[1:], index=X_t.columns)
+
+    for variable in pvalue_by_var.index:
+        assert pvalue_by_var[variable] == approx(
+            expected_by_var[variable], rel=1e-6)
+
+    # summary style never includes the p-value columns
+    summary = scorecard.table(style="summary")
+    assert "P-value" not in summary.columns
+
+    # not defined for L1/elastic-net penalties: no error, no columns
+    scorecard_l1 = Scorecard(
+        binning_process=BinningProcess(variable_names=list(X.columns)),
+        estimator=LogisticRegression(penalty="l1", solver="liblinear"),
+        scaling_method=None).fit(X, y)
+    assert "P-value" not in scorecard_l1.table(style="detailed").columns
+
+    # not defined for a continuous target / non-LogisticRegression
+    # estimator: no error, no columns
+    y_cont = X["mean radius"].values + 1.0
+    scorecard_cont = Scorecard(
+        binning_process=BinningProcess(variable_names=list(X.columns)),
+        estimator=LinearRegression(),
+        scaling_method=None).fit(X, y_cont)
+    assert "P-value" not in scorecard_cont.table(style="detailed").columns
+
+
 def test_missing_metrics():
     data = pd.DataFrame(
         {'target': np.hstack(


### PR DESCRIPTION
Fixes #224: adds `Std. Error`, `Z-score` and `P-value` columns to `Scorecard.table(style="detailed")`, one row per variable (mirroring how `Coefficient` is already repeated across a variable's bins) -- the same output shape as `statsmodels`' `Logit(...).fit().summary()`.

Only computed for a binary target fit with `LogisticRegression` using no penalty or an L2 penalty. The covariance matrix is the inverse Hessian of the log-likelihood (with the L2 term added back in for a penalized fit, following scikit-learn's own convention of not penalizing the intercept). L1 and elastic-net penalties aren't smooth at zero and have no such closed-form covariance -- rather than return a misleading number, this logs a warning and leaves the columns off. With an L2 penalty the p-values are the standard approximation: exact only as the penalty vanishes (`penalty=None` or a very large `C`), since shrinkage biases both the coefficients and this test toward "not significant".

Handles scikit-learn's ongoing `penalty` → `l1_ratio` API migration (>= 1.8): a plain `LogisticRegression()` leaves `penalty` at an internal `'deprecated'` sentinel rather than `'l2'`, which an earlier version of this patch missed -- it silently skipped the L2 covariance correction for the single most common (default) case. Fixed with a small `_resolve_penalty()` helper and verified across unregularized, default-L2, near-infinite-C, explicit-L1, new-API-elasticnet and new-API-L2 cases, plus a sample-weighted fit.

Verified: cross-checked against `statsmodels` (test-only, not a new dependency) -- matches an unregularized fit to 5+ significant figures, matches a sample-weighted fit closely. 17/18 `test_scorecard.py` tests pass; the one failure (`test_missing_metrics`) is the pre-existing pandas-3.x issue from #399, confirmed to fail identically on a clean worktree with none of these changes. Added a `test_pvalues` regression test with an independent recomputation of the Wald formula as a cross-check. flake8 clean.

Fixes #224.