### PR TITLE
Auto-detect dtype in OptimalBinning and ContinuousOptimalBinning

### DIFF
--- a/optbinning/binning/binning.py
+++ b/optbinning/binning/binning.py
@@ -9,6 +9,7 @@ import numbers
 import time
 
 import numpy as np
+import pandas as pd
 
 from sklearn.utils import check_array
 
@@ -29,6 +30,7 @@ from .cp import BinningCP
 from .ls import BinningLS
 from .mip import BinningMIP
 from .prebinning import PreBinning
+from .preprocessing import _check_variable_dtype
 from .preprocessing import preprocessing_user_splits_categorical
 from .preprocessing import split_data
 from .transformations import transform_binary_target
@@ -50,9 +52,9 @@ def _check_parameters(name, dtype, prebinning_method, solver, divergence,
     if not isinstance(name, str):
         raise TypeError("name must be a string.")
 
-    if dtype not in ("categorical", "numerical"):
+    if dtype is not None and dtype not in ("categorical", "numerical"):
         raise ValueError('Invalid value for dtype. Allowed string '
-                         'values are "categorical" and "numerical".')
+                         'values are "categorical", "numerical" and None.')
 
     if prebinning_method not in ("cart", "mdlp", "quantile", "uniform"):
         raise ValueError('Invalid value for prebinning_method. Allowed string '
@@ -258,10 +260,16 @@ class OptimalBinning(BaseOptimalBinning):
     name : str, optional (default="")
         The variable name.
 
-    dtype : str, optional (default="numerical")
+    dtype : str or None, optional (default=None)
         The variable data type. Supported data types are "numerical" for
         continuous and ordinal variables and "categorical" for categorical
-        and nominal variables.
+        and nominal variables. If None, the data type is inferred from
+        ``x`` at fit time: "categorical" for an object, string or pandas
+        ``category`` dtype, "numerical" otherwise.
+
+        .. versionchanged:: 0.21.0
+           ``dtype`` is now optional; the default changed from
+           ``"numerical"`` to auto-detection.
 
     prebinning_method : str, optional (default="cart")
         The pre-binning method. Supported methods are "cart" for a CART
@@ -444,7 +452,7 @@ class OptimalBinning(BaseOptimalBinning):
     The mathematical formulation when ``solver="ls"`` does **not** currently
     support the ``max_pvalue`` constraint.
     """
-    def __init__(self, name="", dtype="numerical", prebinning_method="cart",
+    def __init__(self, name="", dtype=None, prebinning_method="cart",
                  solver="cp", divergence="iv", max_n_prebins=20,
                  min_prebin_size=0.05, min_n_bins=None, max_n_bins=None,
                  min_bin_size=None, max_bin_size=None, min_bin_n_nonevent=None,
@@ -501,6 +509,7 @@ class OptimalBinning(BaseOptimalBinning):
         self.prebinning_kwargs = prebinning_kwargs
 
         # auxiliary
+        self._dtype = None
         self._flag_min_n_event_nonevent = False
         self._categories = None
         self._cat_others = None
@@ -659,7 +668,7 @@ class OptimalBinning(BaseOptimalBinning):
         """
         self._check_is_fitted()
 
-        return transform_binary_target(self._splits_optimal, self.dtype, x,
+        return transform_binary_target(self._splits_optimal, self._dtype, x,
                                        self._n_nonevent, self._n_event,
                                        self.special_codes, self._categories,
                                        self._cat_others, self.cat_unknown,
@@ -710,6 +719,13 @@ class OptimalBinning(BaseOptimalBinning):
 
         _check_parameters(**self.get_params())
 
+        # Determine variable dtype: use user-provided dtype, otherwise
+        # infer it from the data. See GH issue #316.
+        if self.dtype is None:
+            self._dtype = _check_variable_dtype(pd.Series(x))
+        else:
+            self._dtype = self.dtype
+
         # Pre-processing
         if self.verbose:
             logger.info("Pre-processing started.")
@@ -730,7 +746,7 @@ class OptimalBinning(BaseOptimalBinning):
         [x_clean, y_clean, x_missing, y_missing, x_special, y_special,
          y_others, categories, cat_others, sw_clean, sw_missing,
          sw_special, sw_others] = split_data(
-            self.dtype, x, y, self.special_codes, self.cat_cutoff,
+            self._dtype, x, y, self.special_codes, self.cat_cutoff,
             self.user_splits, check_input, self.outlier_detector,
             self.outlier_params, None, None, self.class_weight, sample_weight)
 
@@ -755,7 +771,7 @@ class OptimalBinning(BaseOptimalBinning):
                 logger.info("Pre-processing: number of outlier samples: "
                             "{}".format(n_outlier))
 
-            if self.dtype == "categorical":
+            if self._dtype == "categorical":
                 n_categories = len(categories)
                 n_categories_others = len(cat_others)
                 n_others = len(y_others)
@@ -790,7 +806,7 @@ class OptimalBinning(BaseOptimalBinning):
                 n_nonevent = np.array([])
                 n_event = np.array([])
             else:
-                if self.dtype == "numerical":
+                if self._dtype == "numerical":
                     user_splits = check_array(
                         self.user_splits, ensure_2d=False, dtype=None,
                         ensure_all_finite=True)
@@ -856,7 +872,7 @@ class OptimalBinning(BaseOptimalBinning):
             self._n_event_special, self._n_nonevent_cat_others,
             self._n_event_cat_others, cat_others)
 
-        if self.dtype == "numerical":
+        if self._dtype == "numerical":
             min_x = x_clean.min()
             max_x = x_clean.max()
         else:
@@ -864,7 +880,7 @@ class OptimalBinning(BaseOptimalBinning):
             max_x = None
 
         self._binning_table = BinningTable(
-            self.name, self.dtype, self.special_codes, self._splits_optimal,
+            self.name, self._dtype, self.special_codes, self._splits_optimal,
             self._n_nonevent, self._n_event, min_x, max_x, self._categories,
             self._cat_others, self.user_splits)
 
@@ -953,7 +969,7 @@ class OptimalBinning(BaseOptimalBinning):
         # Monotonic trend
         trend_change = None
 
-        if self.dtype == "numerical":
+        if self._dtype == "numerical":
             auto_monotonic_modes = ("auto", "auto_heuristic", "auto_asc_desc")
             if self.monotonic_trend in auto_monotonic_modes:
                 monotonic = auto_monotonic(n_nonevent, n_event,
@@ -1040,7 +1056,7 @@ class OptimalBinning(BaseOptimalBinning):
             self.solver, optimizer.solver_)
         self._status = status
 
-        if self.dtype == "categorical" and self.user_splits is not None:
+        if self._dtype == "categorical" and self.user_splits is not None:
             self._splits_optimal = splits[solution]
         else:
             self._splits_optimal = splits[solution[:-1]]
@@ -1087,7 +1103,7 @@ class OptimalBinning(BaseOptimalBinning):
         if not n_splits:
             return splits_prebinning, np.array([]), np.array([])
 
-        if self.dtype == "categorical" and self.user_splits is not None:
+        if self._dtype == "categorical" and self.user_splits is not None:
             indices = np.digitize(x, splits_prebinning, right=True)
             n_bins = n_splits
         else:
@@ -1110,7 +1126,7 @@ class OptimalBinning(BaseOptimalBinning):
             else:
                 self._n_refinements += 1
 
-                if (self.dtype == "categorical" and
+                if (self._dtype == "categorical" and
                         self.user_splits is not None):
                     mask_splits = mask_remove
                 else:
@@ -1168,7 +1184,7 @@ class OptimalBinning(BaseOptimalBinning):
         """
         self._check_is_fitted()
 
-        if self.dtype == "numerical":
+        if self._dtype == "numerical":
             return self._splits_optimal
         else:
             return bin_categorical(self._splits_optimal, self._categories,

--- a/optbinning/binning/binning_process.py
+++ b/optbinning/binning/binning_process.py
@@ -29,6 +29,7 @@ from .continuous_binning import ContinuousOptimalBinning
 from .multiclass_binning import MulticlassOptimalBinning
 from .piecewise.binning import OptimalPWBinning
 from .piecewise.continuous_binning import ContinuousOptimalPWBinning
+from .preprocessing import _check_variable_dtype
 
 
 logger = Logger(__name__).logger
@@ -306,10 +307,6 @@ def _check_parameters(variable_names, max_n_prebins, min_prebin_size,
 
     if not isinstance(verbose, bool):
         raise TypeError("verbose must be a boolean; got {}.".format(verbose))
-
-
-def _check_variable_dtype(x):
-    return "categorical" if x.dtype == object else "numerical"
 
 
 class BaseBinningProcess:

--- a/optbinning/binning/continuous_binning.py
+++ b/optbinning/binning/continuous_binning.py
@@ -12,6 +12,7 @@ import json
 from sklearn.utils import check_array
 
 import numpy as np
+import pandas as pd
 
 from ..information import solver_statistics
 from ..logging import Logger
@@ -22,6 +23,7 @@ from .binning_statistics import continuous_bin_info
 from .binning_statistics import ContinuousBinningTable
 from .binning_statistics import target_info_special_continuous
 from .continuous_cp import ContinuousBinningCP
+from .preprocessing import _check_variable_dtype
 from .preprocessing import preprocessing_user_splits_categorical
 from .preprocessing import split_data
 from .transformations import transform_continuous_target
@@ -41,9 +43,9 @@ def _check_parameters(name, dtype, prebinning_method, max_n_prebins,
     if not isinstance(name, str):
         raise TypeError("name must be a string.")
 
-    if dtype not in ("categorical", "numerical"):
+    if dtype is not None and dtype not in ("categorical", "numerical"):
         raise ValueError('Invalid value for dtype. Allowed string '
-                         'values are "categorical" and "numerical".')
+                         'values are "categorical", "numerical" and None.')
 
     if prebinning_method not in ("cart", "quantile", "uniform"):
         raise ValueError('Invalid value for prebinning_method. Allowed string '
@@ -191,10 +193,16 @@ class ContinuousOptimalBinning(OptimalBinning):
     name : str, optional (default="")
         The variable name.
 
-    dtype : str, optional (default="numerical")
+    dtype : str or None, optional (default=None)
         The variable data type. Supported data types are "numerical" for
         continuous and ordinal variables and "categorical" for categorical
-        and nominal variables.
+        and nominal variables. If None, the data type is inferred from
+        ``x`` at fit time: "categorical" for an object, string or pandas
+        ``category`` dtype, "numerical" otherwise.
+
+        .. versionchanged:: 0.21.0
+           ``dtype`` is now optional; the default changed from
+           ``"numerical"`` to auto-detection.
 
     prebinning_method : str, optional (default="cart")
         The pre-binning method. Supported methods are "cart" for a CART
@@ -324,7 +332,7 @@ class ContinuousOptimalBinning(OptimalBinning):
     The pre-binning refinement phase guarantee that no prebin has zero number
     of records by merging those pure prebins. Pure bins produce infinity mean.
     """
-    def __init__(self, name="", dtype="numerical", prebinning_method="cart",
+    def __init__(self, name="", dtype=None, prebinning_method="cart",
                  max_n_prebins=20, min_prebin_size=0.05, min_n_bins=None,
                  max_n_bins=None, min_bin_size=None, max_bin_size=None,
                  monotonic_trend="auto", min_mean_diff=0, max_pvalue=None,
@@ -370,6 +378,7 @@ class ContinuousOptimalBinning(OptimalBinning):
         self.prebinning_kwargs = prebinning_kwargs
 
         # auxiliary
+        self._dtype = None
         self._categories = None
         self._cat_others = None
         self._n_records = None
@@ -540,7 +549,7 @@ class ContinuousOptimalBinning(OptimalBinning):
         """
         self._check_is_fitted()
 
-        return transform_continuous_target(self._splits_optimal, self.dtype,
+        return transform_continuous_target(self._splits_optimal, self._dtype,
                                            x, self._n_records, self._sums,
                                            self.special_codes,
                                            self._categories, self._cat_others,
@@ -557,6 +566,13 @@ class ContinuousOptimalBinning(OptimalBinning):
             logger.info("Options: check parameters.")
 
         _check_parameters(**self.get_params())
+
+        # Determine variable dtype: use user-provided dtype, otherwise
+        # infer it from the data. See GH issue #316.
+        if self.dtype is None:
+            self._dtype = _check_variable_dtype(pd.Series(x))
+        else:
+            self._dtype = self.dtype
 
         # Pre-processing
         if self.verbose:
@@ -578,7 +594,7 @@ class ContinuousOptimalBinning(OptimalBinning):
         [x_clean, y_clean, x_missing, y_missing, x_special, y_special,
          y_others, categories, cat_others, sw_clean, sw_missing, sw_special,
          sw_others] = split_data(
-            self.dtype, x, y, self.special_codes, self.cat_cutoff,
+            self._dtype, x, y, self.special_codes, self.cat_cutoff,
             self.user_splits, check_input, self.outlier_detector,
             self.outlier_params, None, None, None, sample_weight)
 
@@ -603,7 +619,7 @@ class ContinuousOptimalBinning(OptimalBinning):
                 logger.info("Pre-processing: number of outlier samples: {}"
                             .format(n_outlier))
 
-            if self.dtype == "categorical":
+            if self._dtype == "categorical":
                 n_categories = len(categories)
                 n_categories_others = len(cat_others)
                 n_others = len(y_others)
@@ -639,7 +655,7 @@ class ContinuousOptimalBinning(OptimalBinning):
                 sums = np.array([])
                 stds = np.array([])
             else:
-                if self.dtype == "numerical":
+                if self._dtype == "numerical":
                     user_splits = check_array(
                         self.user_splits, ensure_2d=False, dtype=None,
                         ensure_all_finite=True)
@@ -717,7 +733,7 @@ class ContinuousOptimalBinning(OptimalBinning):
             self._min_target_others, self._max_target_others,
             self._n_zeros_others, self._cat_others)
 
-        if self.dtype == "numerical":
+        if self._dtype == "numerical":
             min_x = x_clean.min()
             max_x = x_clean.max()
         else:
@@ -725,7 +741,7 @@ class ContinuousOptimalBinning(OptimalBinning):
             max_x = None
 
         self._binning_table = ContinuousBinningTable(
-            self.name, self.dtype, self.special_codes, self._splits_optimal,
+            self.name, self._dtype, self.special_codes, self._splits_optimal,
             self._n_records, self._sums, self._stds, self._min_target,
             self._max_target, self._n_zeros, min_x, max_x, self._categories,
             self._cat_others, self.user_splits)
@@ -778,7 +794,7 @@ class ContinuousOptimalBinning(OptimalBinning):
         # Monotonic trend
         trend_change = None
 
-        if self.dtype == "numerical":
+        if self._dtype == "numerical":
             auto_monotonic_modes = ("auto", "auto_heuristic", "auto_asc_desc")
             if self.monotonic_trend in auto_monotonic_modes:
                 monotonic = auto_monotonic_continuous(
@@ -843,7 +859,7 @@ class ContinuousOptimalBinning(OptimalBinning):
             self.solver, optimizer.solver_)
         self._status = status
 
-        if self.dtype == "categorical" and self.user_splits is not None:
+        if self._dtype == "categorical" and self.user_splits is not None:
             self._splits_optimal = splits[solution]
         else:
             self._splits_optimal = splits[solution[:-1]]
@@ -909,7 +925,7 @@ class ContinuousOptimalBinning(OptimalBinning):
             return (splits_prebinning, np.array([]), np.array([]), np.array([]),
                     np.array([]), np.array([]), np.array([]), np.array([]))
 
-        if self.dtype == "categorical" and self.user_splits is not None:
+        if self._dtype == "categorical" and self.user_splits is not None:
             indices = np.digitize(x, splits_prebinning, right=True)
             n_bins = n_splits
         else:
@@ -942,7 +958,7 @@ class ContinuousOptimalBinning(OptimalBinning):
         if np.any(mask_remove):
             self._n_refinements += 1
 
-            if (self.dtype == "categorical" and
+            if (self._dtype == "categorical" and
                     self.user_splits is not None):
                 mask_splits = mask_remove
             else:

--- a/optbinning/binning/preprocessing.py
+++ b/optbinning/binning/preprocessing.py
@@ -21,6 +21,23 @@ from .outlier import RangeDetector
 from .outlier import YQuantileDetector
 
 
+def _check_variable_dtype(x):
+    """Infer whether a variable is numerical or categorical from its
+    values. Shared by ``OptimalBinning`` and ``BinningProcess`` (kept
+    here since neither module can import from the other).
+
+    A pandas ``category`` column is always categorical, regardless of
+    its categories' dtype; otherwise, anything not numeric (including
+    raw numpy string/unicode arrays) is categorical. See GH issue #316.
+    """
+    if isinstance(x.dtype, pd.CategoricalDtype):
+        return "categorical"
+    elif pd.api.types.is_numeric_dtype(x):
+        return "numerical"
+    else:
+        return "categorical"
+
+
 def categorical_transform(x, y):
     event_rate = pd.Series(y).groupby(x).mean()
     sorted_categories = event_rate.sort_values().index.values

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -339,6 +339,85 @@ def test_categorical_default_user_splits():
     assert optb.status == "OPTIMAL"
 
 
+def test_dtype_autodetect():
+    # dtype=None (the new default) infers the variable type from the data.
+    # See GH issue #316.
+    x_cat = np.array([
+        'Working', 'State servant', 'Working', 'Working', 'Working',
+        'State servant', 'Commercial associate', 'State servant',
+        'Pensioner', 'Working', 'Working', 'Pensioner', 'Working',
+        'Working', 'Working', 'Working', 'Working', 'Working', 'Working',
+        'State servant', 'Working', 'Commercial associate', 'Working',
+        'Pensioner', 'Working', 'Working', 'Working', 'Working',
+        'State servant', 'Working', 'Commercial associate', 'Working',
+        'Working', 'Commercial associate', 'State servant', 'Working',
+        'Commercial associate', 'Working', 'Pensioner', 'Working',
+        'Commercial associate', 'Working', 'Working', 'Pensioner',
+        'Working', 'Working', 'Pensioner', 'Working', 'State servant',
+        'Working', 'State servant', 'Commercial associate', 'Working',
+        'Commercial associate', 'Pensioner', 'Working', 'Pensioner',
+        'Working', 'Working', 'Working', 'Commercial associate', 'Working',
+        'Pensioner', 'Working', 'Commercial associate',
+        'Commercial associate', 'State servant', 'Working',
+        'Commercial associate', 'Commercial associate',
+        'Commercial associate', 'Working', 'Working', 'Working',
+        'Commercial associate', 'Working', 'Commercial associate',
+        'Working', 'Working', 'Pensioner', 'Working', 'Pensioner',
+        'Working', 'Working', 'Pensioner', 'Working', 'State servant',
+        'Working', 'Working', 'Working', 'Working', 'Working',
+        'Commercial associate', 'Commercial associate',
+        'Commercial associate', 'Working', 'Commercial associate',
+        'Working', 'Working', 'Pensioner'], dtype=object)
+
+    y_cat = np.array([
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+
+    # default constructor now uses dtype=None
+    optb = OptimalBinning()
+    assert optb.dtype is None
+
+    # numerical data (numpy array of floats) is inferred as "numerical"
+    optb = OptimalBinning()
+    optb.fit(x, y)
+    assert optb._dtype == "numerical"
+    assert optb.status == "OPTIMAL"
+
+    # object-dtype string array is inferred as "categorical"
+    optb = OptimalBinning(solver="mip", cat_cutoff=0.1)
+    optb.fit(x_cat, y_cat)
+    assert optb._dtype == "categorical"
+    assert optb.status == "OPTIMAL"
+
+    # plain numpy unicode string array (not dtype=object) is also
+    # inferred as "categorical"
+    x_cat_unicode = np.array(x_cat, dtype=str)
+    optb = OptimalBinning(solver="mip", cat_cutoff=0.1)
+    optb.fit(x_cat_unicode, y_cat)
+    assert optb._dtype == "categorical"
+
+    # pandas category dtype with *numeric* categories is inferred as
+    # "categorical", not "numerical"
+    x_coded = pd.Series(pd.Categorical(
+        np.random.RandomState(0).choice([1, 2, 3], size=len(x_cat))))
+    optb = OptimalBinning(solver="mip", cat_cutoff=0.1)
+    optb.fit(x_coded, y_cat)
+    assert optb._dtype == "categorical"
+
+    # explicit dtype still overrides auto-detection
+    optb = OptimalBinning(dtype="numerical")
+    optb.fit(x, y)
+    assert optb._dtype == "numerical"
+
+    # invalid explicit dtype values are still rejected
+    with raises(ValueError):
+        optb = OptimalBinning(dtype="nominal")
+        optb.fit(x, y)
+
+
 def test_categorical_user_splits():
     np.random.seed(0)
     n = 100000

--- a/tests/test_continuous_binning.py
+++ b/tests/test_continuous_binning.py
@@ -203,6 +203,55 @@ def test_categorical_user_splits():
         assert optb.status == "OPTIMAL"
 
 
+def test_dtype_autodetect():
+    # dtype=None (the new default) infers the variable type from the data.
+    # See GH issue #316.
+    np.random.seed(0)
+    n = 300
+    x_cat = np.random.choice(
+        ["Working", "Pensioner", "Student"], size=n).astype(object)
+    y_cat = np.random.normal(size=n)
+
+    # default constructor now uses dtype=None
+    optb = ContinuousOptimalBinning()
+    assert optb.dtype is None
+
+    # numerical data is inferred as "numerical"
+    optb = ContinuousOptimalBinning()
+    optb.fit(x, y)
+    assert optb._dtype == "numerical"
+
+    # object-dtype string array is inferred as "categorical"
+    optb = ContinuousOptimalBinning()
+    optb.fit(x_cat, y_cat)
+    assert optb._dtype == "categorical"
+
+    # plain numpy unicode string array (not dtype=object) is also
+    # inferred as "categorical"
+    x_cat_unicode = np.array(x_cat, dtype=str)
+    optb = ContinuousOptimalBinning()
+    optb.fit(x_cat_unicode, y_cat)
+    assert optb._dtype == "categorical"
+
+    # pandas category dtype with *numeric* categories is inferred as
+    # "categorical", not "numerical"
+    x_coded = pd.Series(pd.Categorical(
+        np.random.choice([1, 2, 3], size=n)))
+    optb = ContinuousOptimalBinning()
+    optb.fit(x_coded, y_cat)
+    assert optb._dtype == "categorical"
+
+    # explicit dtype still overrides auto-detection
+    optb = ContinuousOptimalBinning(dtype="numerical")
+    optb.fit(x, y)
+    assert optb._dtype == "numerical"
+
+    # invalid explicit dtype values are still rejected
+    with raises(ValueError):
+        optb = ContinuousOptimalBinning(dtype="nominal")
+        optb.fit(x, y)
+
+
 def test_numerical_max_pvalue():
     optb0 = ContinuousOptimalBinning(max_pvalue=0.05,
                                      max_pvalue_policy="consecutive")


### PR DESCRIPTION
Fixes #316.

`OptimalBinning` and `ContinuousOptimalBinning` required `dtype` to be set explicitly (default was `"numerical"`), while `BinningProcess` already auto-detected it per column. This brings the two single-variable classes in line: `dtype` now defaults to `None` and is inferred from the data at fit time, exactly like `BinningProcess` already does.

Along the way I found the shared detection helper only checked `x.dtype == object`, which misses two real cases: a plain numpy string/unicode array (e.g. `np.array(["a", "b"])`, dtype `<U1`) and a pandas `category` column whose categories happen to be numeric (e.g. a coded ZIP or grade level). Both are now correctly detected as categorical. I relocated the helper to `preprocessing.py` (the lower-level module both `binning.py` and `binning_process.py` import from) since `binning_process.py` imports from `binning.py`, so `binning.py` importing back from `binning_process.py` would create a cycle.

Explicit `dtype="numerical"`/`dtype="categorical"` still works exactly as before and overrides auto-detection.

Tests: added `test_dtype_autodetect` to `test_binning.py` and `test_continuous_binning.py` covering numerical, object-string, numpy-unicode-string, and numeric-pandas-category inputs, explicit-override, and invalid-value rejection. Full `test_binning.py`/`test_continuous_binning.py`/`test_binning_process.py` suites pass (56/56); flake8 clean on the touched files.